### PR TITLE
fix!: require explicit size in AddPageWithAsset

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ For fixed-layout workflows, you can add both asset and page in one call:
 ```go
 _, _, err = doc.AddPageWithAsset(
 	img,
+	st.Size(),
 	"right",
 )
 if err != nil {

--- a/cmd/epub/main.go
+++ b/cmd/epub/main.go
@@ -290,13 +290,13 @@ func runBuildFromImages(args []string) error {
 	}()
 
 	for _, p := range imagePaths {
-		f, _, err := openReaderAt(p)
+		f, size, err := openReaderAt(p)
 		if err != nil {
 			return err
 		}
 		openFiles = append(openFiles, f)
 
-		if _, _, err := doc.AddPageWithAsset(f, spreadNorm); err != nil {
+		if _, _, err := doc.AddPageWithAsset(f, size, spreadNorm); err != nil {
 			return err
 		}
 	}

--- a/doc.go
+++ b/doc.go
@@ -29,7 +29,8 @@
 //
 //	img, _ := os.Open("./p-001.jpg")
 //	defer img.Close()
+//	st, _ := img.Stat()
 //	doc := &epub.Document{Title: "Demo", Direction: "rtl", Layout: epub.LayoutPrePaginated}
-//	_, _, _ = doc.AddPageWithAsset(img, "right")
+//	_, _, _ = doc.AddPageWithAsset(img, st.Size(), "right")
 //	_ = epub.Encode(io.Discard, doc)
 package epub

--- a/encode_test.go
+++ b/encode_test.go
@@ -56,7 +56,8 @@ func TestEncodeDecode_RoundTripBasic(t *testing.T) {
 		Direction: "ltr",
 		Layout:    LayoutPrePaginated,
 	}
-	page, asset, err := doc.AddPageWithAsset(bytes.NewReader(testPNGBytes()), "right")
+	png := testPNGBytes()
+	page, asset, err := doc.AddPageWithAsset(bytes.NewReader(png), int64(len(png)), "right")
 	if err != nil {
 		t.Fatalf("AddPageWithAsset failed: %v", err)
 	}

--- a/epub.go
+++ b/epub.go
@@ -145,10 +145,10 @@ func (d *Document) AddAsset(mimeType string, r io.ReaderAt, size int64) (string,
 
 // AddPageWithAsset registers an asset and appends its page in one call.
 //
-// mime type, byte size, and viewport width/height are derived from r.
+// mime type and viewport width/height are derived from r.
 // If page creation fails after asset registration, the asset is rolled back.
-func (d *Document) AddPageWithAsset(r io.ReaderAt, spread string) (*Page, *Asset, error) {
-	mimeType, size, width, height, err := detectAssetMeta(r)
+func (d *Document) AddPageWithAsset(r io.ReaderAt, size int64, spread string) (*Page, *Asset, error) {
+	mimeType, width, height, err := detectAssetMeta(r, size)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -168,16 +168,12 @@ func (d *Document) AddPageWithAsset(r io.ReaderAt, spread string) (*Page, *Asset
 	return page, asset, nil
 }
 
-func detectAssetMeta(r io.ReaderAt) (mimeType string, size int64, width int, height int, err error) {
+func detectAssetMeta(r io.ReaderAt, size int64) (mimeType string, width int, height int, err error) {
 	if r == nil {
-		return "", 0, 0, 0, ErrNilReaderAt
-	}
-	size, err = readerAtSize(r)
-	if err != nil {
-		return "", 0, 0, 0, err
+		return "", 0, 0, ErrNilReaderAt
 	}
 	if size <= 0 {
-		return "", 0, 0, 0, ErrInvalidAssetSize
+		return "", 0, 0, ErrInvalidAssetSize
 	}
 
 	headLen := int64(512)
@@ -187,18 +183,18 @@ func detectAssetMeta(r io.ReaderAt) (mimeType string, size int64, width int, hei
 	head := make([]byte, headLen)
 	n, err := r.ReadAt(head, 0)
 	if err != nil && !errors.Is(err, io.EOF) {
-		return "", 0, 0, 0, err
+		return "", 0, 0, err
 	}
 	mimeType = http.DetectContentType(head[:n])
 	if !strings.HasPrefix(mimeType, "image/") {
-		return "", 0, 0, 0, ErrCannotInferAssetPath
+		return "", 0, 0, ErrCannotInferAssetPath
 	}
 
 	cfg, _, err := image.DecodeConfig(io.NewSectionReader(r, 0, size))
 	if err != nil {
-		return "", 0, 0, 0, err
+		return "", 0, 0, err
 	}
-	return mimeType, size, cfg.Width, cfg.Height, nil
+	return mimeType, cfg.Width, cfg.Height, nil
 }
 
 func readerAtSize(r io.ReaderAt) (int64, error) {

--- a/epub_example.go
+++ b/epub_example.go
@@ -35,7 +35,7 @@ func ExampleDocument_AddPageWithAsset() {
 	pngBytes, _ := base64.StdEncoding.DecodeString("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7Zk7kAAAAASUVORK5CYII=")
 	img := bytes.NewReader(pngBytes)
 
-	page, asset, err := doc.AddPageWithAsset(img, "right")
+	page, asset, err := doc.AddPageWithAsset(img, int64(img.Len()), "right")
 	if err != nil {
 		fmt.Println("error")
 		return

--- a/epub_test.go
+++ b/epub_test.go
@@ -54,7 +54,7 @@ func TestAddPageWithAssetSharesID(t *testing.T) {
 	}
 	r := bytes.NewReader(pngBytes)
 
-	page, asset, err := doc.AddPageWithAsset(r, "left")
+	page, asset, err := doc.AddPageWithAsset(r, int64(r.Len()), "left")
 	if err != nil {
 		t.Fatalf("AddPageWithAsset returned error: %v", err)
 	}


### PR DESCRIPTION
## Summary
- make AddPageWithAsset require an explicit size int64 argument
- pass the provided size directly into asset metadata detection
- update tests, examples, docs, README, and CLI call sites

## Why
This removes internal size inference in AddPageWithAsset, avoiding binary-search overhead for non-local io.ReaderAt sources such as remote streams.

## Validation
- go test ./...

Closes #7