### PR TITLE
feat: add high-level page asset resolution APIs

### DIFF
--- a/epub.go
+++ b/epub.go
@@ -60,6 +60,39 @@ func (d *Document) IsPrePaginated() bool {
 	return d != nil && d.Layout == LayoutPrePaginated
 }
 
+// GetAssetByPage resolves the corresponding asset from the given page reference.
+func (d *Document) GetAssetByPage(p *Page) (*Asset, error) {
+	if d == nil {
+		return nil, ErrNilDocument
+	}
+	if p == nil {
+		return nil, ErrNilPage
+	}
+	if strings.TrimSpace(p.AssetID) == "" {
+		return nil, ErrEmptyAssetID
+	}
+
+	for _, a := range d.Assets {
+		if a != nil && a.ID == p.AssetID {
+			return a, nil
+		}
+	}
+	return nil, ErrAssetNotFound
+}
+
+// ResolveSpineAssets verifies that all pages in spine can resolve to existing assets.
+func (d *Document) ResolveSpineAssets() error {
+	if d == nil {
+		return ErrNilDocument
+	}
+	for i, p := range d.Pages {
+		if _, err := d.GetAssetByPage(p); err != nil {
+			return fmt.Errorf("page[%d]: %w", i, err)
+		}
+	}
+	return nil
+}
+
 // AddPage appends a new page and automatically assigns reading order.
 //
 // For reflowable content, width/height can be 0 and spread can be empty.

--- a/epub_test.go
+++ b/epub_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"errors"
+	"io"
 	"strings"
 	"testing"
 )
@@ -77,4 +78,102 @@ func TestAddAssetUnsupportedMime(t *testing.T) {
 	if !errors.Is(err, ErrCannotInferAssetPath) {
 		t.Fatalf("expected ErrCannotInferAssetPath, got: %v", err)
 	}
+}
+
+func TestDocumentGetAssetByPage(t *testing.T) {
+	doc := &Document{}
+	pngBytes, err := base64.StdEncoding.DecodeString("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7Zk7kAAAAASUVORK5CYII=")
+	if err != nil {
+		t.Fatalf("decode png fixture: %v", err)
+	}
+
+	page, asset, err := doc.AddPageWithAsset(bytes.NewReader(pngBytes), int64(len(pngBytes)), "right")
+	if err != nil {
+		t.Fatalf("AddPageWithAsset returned error: %v", err)
+	}
+
+	resolved, err := doc.GetAssetByPage(page)
+	if err != nil {
+		t.Fatalf("GetAssetByPage returned error: %v", err)
+	}
+	if resolved != asset {
+		t.Fatal("resolved asset pointer should match returned asset")
+	}
+}
+
+func TestDocumentGetAssetByPageErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  *Document
+		page *Page
+		want error
+	}{
+		{
+			name: "nil document",
+			doc:  nil,
+			page: &Page{AssetID: "p-001"},
+			want: ErrNilDocument,
+		},
+		{
+			name: "nil page",
+			doc:  &Document{},
+			page: nil,
+			want: ErrNilPage,
+		},
+		{
+			name: "empty asset id",
+			doc:  &Document{},
+			page: &Page{AssetID: ""},
+			want: ErrEmptyAssetID,
+		},
+		{
+			name: "asset not found",
+			doc:  &Document{Assets: map[string]*Asset{"item/image/p-002.jpg": {ID: "p-002", Open: func() (io.ReadCloser, error) { return io.NopCloser(strings.NewReader("x")), nil }}}},
+			page: &Page{AssetID: "p-001"},
+			want: ErrAssetNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.doc.GetAssetByPage(tt.page)
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("expected %v, got: %v", tt.want, err)
+			}
+		})
+	}
+}
+
+func TestDocumentResolveSpineAssets(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		doc := &Document{}
+		pngBytes, err := base64.StdEncoding.DecodeString("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7Zk7kAAAAASUVORK5CYII=")
+		if err != nil {
+			t.Fatalf("decode png fixture: %v", err)
+		}
+		if _, _, err := doc.AddPageWithAsset(bytes.NewReader(pngBytes), int64(len(pngBytes)), "none"); err != nil {
+			t.Fatalf("AddPageWithAsset returned error: %v", err)
+		}
+
+		if err := doc.ResolveSpineAssets(); err != nil {
+			t.Fatalf("ResolveSpineAssets returned error: %v", err)
+		}
+	})
+
+	t.Run("invalid reference", func(t *testing.T) {
+		doc := &Document{
+			Pages: []*Page{{Order: 0, AssetID: "p-001"}},
+			Assets: map[string]*Asset{
+				"item/image/p-002.jpg": {
+					ID:       "p-002",
+					MimeType: "image/jpeg",
+				},
+			},
+		}
+
+		err := doc.ResolveSpineAssets()
+		if !errors.Is(err, ErrAssetNotFound) {
+			t.Fatalf("expected ErrAssetNotFound, got: %v", err)
+		}
+	})
 }

--- a/errors.go
+++ b/errors.go
@@ -30,6 +30,8 @@ var (
 	ErrNilAssetOpen = errors.New("asset Open function is nil")
 	// ErrNilDocument is returned when document receiver is nil.
 	ErrNilDocument = errors.New("document is nil")
+	// ErrNilPage is returned when page argument is nil.
+	ErrNilPage = errors.New("page is nil")
 	// ErrEmptyAssetID is returned when page asset id is empty.
 	ErrEmptyAssetID = errors.New("asset id is empty")
 	// ErrInvalidSpread is returned when page spread is unsupported.


### PR DESCRIPTION
## Summary
- add Document.GetAssetByPage to resolve assets from page references
- add Document.ResolveSpineAssets to pre-verify all spine references
- add ErrNilPage for explicit nil page validation
- add unit tests for success and failure scenarios

## Why
This introduces a higher-level API so callers no longer need to manually match Page.AssetID against Document.Assets.

## Testing
- go test ./...