### PR TITLE
feat: add page href and spine image extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,19 @@ if err != nil {
 }
 ```
 
+When a spine item is XHTML, you can still resolve the referenced page images:
+
+```go
+refs, err := doc.ExtractReferencedImagesFromSpine()
+if err != nil {
+	log.Fatal(err)
+}
+
+for _, ref := range refs {
+	fmt.Println(ref.Page.Order, ref.Page.Href, ref.Href, ref.Asset.ID)
+}
+```
+
 ## Demo CLI
 
 The CLI lives under [cmd/epub](cmd/epub) and has its own documentation:

--- a/cmd/epub/main.go
+++ b/cmd/epub/main.go
@@ -91,7 +91,7 @@ func runInspect(args []string) error {
 		}
 		for i := 0; i < limit; i++ {
 			p := doc.Pages[i]
-			fmt.Printf("[%d] asset=%s spread=%s size=%dx%d\n", p.Order, p.AssetID, p.Spread, p.Width, p.Height)
+			fmt.Printf("[%d] asset=%s href=%s spread=%s size=%dx%d\n", p.Order, p.AssetID, p.Href, p.Spread, p.Width, p.Height)
 		}
 	}
 
@@ -155,35 +155,27 @@ func runListImages(args []string) error {
 		Spread   string `json:"spread,omitempty"`
 	}
 
-	idToHref := make(map[string]string, len(doc.Assets))
-	for href, a := range doc.Assets {
-		if a != nil {
-			idToHref[a.ID] = href
-		}
-	}
-
 	rows := make([]imageRow, 0)
 	switch strings.ToLower(strings.TrimSpace(*mode)) {
 	case "pages":
-		for _, p := range doc.Pages {
-			href, ok := idToHref[p.AssetID]
-			if !ok {
-				continue
-			}
-			a := doc.Assets[href]
-			if a == nil || !strings.HasPrefix(a.MimeType, "image/") {
+		refs, err := doc.ExtractReferencedImagesFromSpine()
+		if err != nil {
+			return err
+		}
+		for _, ref := range refs {
+			if ref.Page == nil || ref.Asset == nil {
 				continue
 			}
 			rows = append(rows, imageRow{
-				Order:    p.Order,
-				AssetID:  p.AssetID,
-				Href:     href,
-				MimeType: a.MimeType,
-				Size:     a.Size,
-				Checksum: a.Checksum,
-				Width:    p.Width,
-				Height:   p.Height,
-				Spread:   p.Spread,
+				Order:    ref.Page.Order,
+				AssetID:  ref.Asset.ID,
+				Href:     ref.Href,
+				MimeType: ref.Asset.MimeType,
+				Size:     ref.Asset.Size,
+				Checksum: ref.Asset.Checksum,
+				Width:    ref.Page.Width,
+				Height:   ref.Page.Height,
+				Spread:   ref.Page.Spread,
 			})
 		}
 	case "all":

--- a/decode.go
+++ b/decode.go
@@ -106,7 +106,7 @@ func Decode(r io.ReaderAt, size int64, opts ...DecodeOption) (*Document, error) 
 		if !ok {
 			return nil, &DecodeError{Path: opfPath, Rule: "spine-idref", Err: ErrAssetNotFound}
 		}
-		page := &Page{Order: i, AssetID: item.ID, Spread: spreadFromProperties(ref.Properties)}
+		page := &Page{Order: i, AssetID: item.ID, Href: item.Href, Spread: spreadFromProperties(ref.Properties)}
 		if doc.IsPrePaginated() && strings.Contains(item.MediaType, "xhtml") {
 			width, height, err := readViewport(filesByName, item.Href)
 			if err != nil {

--- a/decode_test.go
+++ b/decode_test.go
@@ -44,6 +44,39 @@ func TestDecode_PrePaginatedViewport(t *testing.T) {
 	}
 }
 
+func TestDecode_PageHrefAndExtractReferencedImagesFromSpine(t *testing.T) {
+	epubData := makeMinimalEPUB(t, minimalEPUBConfig{
+		mimetypeFirst:    true,
+		prePaginated:     true,
+		withViewport:     true,
+		embeddedImageSrc: "../image/p-001.jpg",
+	})
+	doc, err := Decode(bytes.NewReader(epubData), int64(len(epubData)))
+	if err != nil {
+		t.Fatalf("Decode failed: %v", err)
+	}
+	if doc.Pages[0].Href != "item/xhtml/p-001.xhtml" {
+		t.Fatalf("unexpected page href: %s", doc.Pages[0].Href)
+	}
+
+	refs, err := doc.ExtractReferencedImagesFromSpine()
+	if err != nil {
+		t.Fatalf("ExtractReferencedImagesFromSpine failed: %v", err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("unexpected refs len: %d", len(refs))
+	}
+	if refs[0].Href != "item/image/p-001.jpg" {
+		t.Fatalf("unexpected image href: %s", refs[0].Href)
+	}
+	if refs[0].Asset == nil || refs[0].Asset.ID != "p-001" {
+		t.Fatalf("unexpected image asset: %#v", refs[0].Asset)
+	}
+	if refs[0].Page != doc.Pages[0] {
+		t.Fatal("expected reference to point to first page")
+	}
+}
+
 func TestDecode_MimetypeNotFirst(t *testing.T) {
 	epubData := makeMinimalEPUB(t, minimalEPUBConfig{mimetypeFirst: false})
 	_, err := Decode(bytes.NewReader(epubData), int64(len(epubData)))
@@ -76,11 +109,12 @@ func TestDecode_EBPAJImageNamingViolation(t *testing.T) {
 }
 
 type minimalEPUBConfig struct {
-	mimetypeFirst   bool
-	mimetypeDeflate bool
-	prePaginated    bool
-	withViewport    bool
-	imageHref       string
+	mimetypeFirst    bool
+	mimetypeDeflate  bool
+	prePaginated     bool
+	withViewport     bool
+	imageHref        string
+	embeddedImageSrc string
 }
 
 func makeMinimalEPUB(t *testing.T, cfg minimalEPUBConfig) []byte {
@@ -108,7 +142,12 @@ func makeMinimalEPUB(t *testing.T, cfg minimalEPUBConfig) []byte {
 	}
 	xhtml += `
 </head>
-<body><p>hello</p></body>
+<body><p>hello</p>`
+	if cfg.embeddedImageSrc != "" {
+		xhtml += `
+<img src="` + cfg.embeddedImageSrc + `" alt="embedded"/>`
+	}
+	xhtml += `</body>
 </html>`
 
 	opf := `<?xml version="1.0" encoding="UTF-8"?>

--- a/epub.go
+++ b/epub.go
@@ -5,6 +5,7 @@ package epub
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"image"
@@ -67,6 +68,17 @@ func (d *Document) GetAssetByPage(p *Page) (*Asset, error) {
 	}
 	if p == nil {
 		return nil, ErrNilPage
+	}
+	if href := strings.TrimSpace(p.Href); href != "" {
+		href = cleanOPFRef("", href)
+		if a, ok := d.Assets[href]; ok && a != nil {
+			if strings.TrimSpace(p.AssetID) == "" || a.ID == p.AssetID {
+				return a, nil
+			}
+		}
+		if strings.TrimSpace(p.AssetID) == "" {
+			return nil, ErrAssetNotFound
+		}
 	}
 	if strings.TrimSpace(p.AssetID) == "" {
 		return nil, ErrEmptyAssetID
@@ -197,6 +209,7 @@ func (d *Document) AddPageWithAsset(r io.ReaderAt, size int64, spread string) (*
 		return nil, nil, err
 	}
 	page.AssetID = asset.ID
+	page.Href = assetHref
 
 	return page, asset, nil
 }
@@ -319,6 +332,7 @@ func fileExtFromMimeType(mimeType string) (string, bool) {
 type Page struct {
 	Order   int
 	AssetID string
+	Href    string
 	Width   int
 	Height  int
 	Spread  string // "left", "right", "center", "none".
@@ -331,6 +345,73 @@ type Asset struct {
 	Size     uint64
 	Checksum string
 	Open     func() (io.ReadCloser, error)
+}
+
+// SpineImageReference is an image asset referenced by a page in spine order.
+type SpineImageReference struct {
+	Page  *Page
+	Href  string
+	Asset *Asset
+}
+
+// ExtractReferencedImagesFromSpine returns image assets referenced by spine pages.
+//
+// Direct image pages are returned as-is. XHTML pages are scanned for img/image
+// elements and their manifest-referenced image assets are resolved in reading order.
+func (d *Document) ExtractReferencedImagesFromSpine() ([]SpineImageReference, error) {
+	if d == nil {
+		return nil, ErrNilDocument
+	}
+
+	refs := make([]SpineImageReference, 0, len(d.Pages))
+	for i, page := range d.Pages {
+		if page == nil {
+			return nil, fmt.Errorf("page[%d]: %w", i, ErrNilPage)
+		}
+
+		asset, err := d.GetAssetByPage(page)
+		if err != nil {
+			return nil, fmt.Errorf("page[%d]: %w", i, err)
+		}
+
+		pageHref := strings.TrimSpace(page.Href)
+		if pageHref == "" {
+			pageHref = d.findAssetHref(asset)
+		}
+
+		mimeType := strings.ToLower(strings.TrimSpace(asset.MimeType))
+		if strings.HasPrefix(mimeType, "image/") {
+			refs = append(refs, SpineImageReference{Page: page, Href: pageHref, Asset: asset})
+			continue
+		}
+		if !strings.Contains(mimeType, "xhtml") {
+			continue
+		}
+		if pageHref == "" {
+			return nil, fmt.Errorf("page[%d]: %w", i, ErrEmptyAssetPath)
+		}
+
+		rawRefs, err := extractImageRefsFromAsset(asset)
+		if err != nil {
+			return nil, fmt.Errorf("page[%d]: %w", i, err)
+		}
+		for _, rawRef := range rawRefs {
+			if !isLocalAssetRef(rawRef) {
+				continue
+			}
+			resolved := cleanOPFRef(path.Dir(pageHref), rawRef)
+			imageAsset, ok := d.Assets[resolved]
+			if !ok || imageAsset == nil {
+				return nil, fmt.Errorf("page[%d]: referenced image %q: %w", i, resolved, ErrAssetNotFound)
+			}
+			if !strings.HasPrefix(strings.ToLower(strings.TrimSpace(imageAsset.MimeType)), "image/") {
+				continue
+			}
+			refs = append(refs, SpineImageReference{Page: page, Href: resolved, Asset: imageAsset})
+		}
+	}
+
+	return refs, nil
 }
 
 // CalculateHash computes SHA-256 by streaming from Open without buffering full contents.
@@ -353,4 +434,92 @@ func (a *Asset) CalculateHash() error {
 	}
 	a.Checksum = hex.EncodeToString(h.Sum(nil))
 	return nil
+}
+
+func (d *Document) findAssetHref(target *Asset) string {
+	if d == nil || target == nil {
+		return ""
+	}
+	for href, asset := range d.Assets {
+		if asset == nil {
+			continue
+		}
+		if asset == target || asset.ID == target.ID {
+			return href
+		}
+	}
+	return ""
+}
+
+func extractImageRefsFromAsset(asset *Asset) ([]string, error) {
+	if asset == nil {
+		return nil, ErrNilAsset
+	}
+	if asset.Open == nil {
+		return nil, ErrNilAssetOpen
+	}
+
+	rc, err := asset.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+
+	buf, err := io.ReadAll(rc)
+	if err != nil {
+		return nil, err
+	}
+
+	return extractImageRefsFromXHTML(string(buf))
+}
+
+func extractImageRefsFromXHTML(xhtml string) ([]string, error) {
+	decoder := xml.NewDecoder(strings.NewReader(xhtml))
+	refs := make([]string, 0, 1)
+
+	for {
+		tok, err := decoder.Token()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return refs, nil
+			}
+			return nil, err
+		}
+
+		se, ok := tok.(xml.StartElement)
+		if !ok {
+			continue
+		}
+
+		switch strings.ToLower(se.Name.Local) {
+		case "img":
+			if ref := xmlAttrValue(se.Attr, "src"); ref != "" {
+				refs = append(refs, ref)
+			}
+		case "image":
+			if ref := xmlAttrValue(se.Attr, "href"); ref != "" {
+				refs = append(refs, ref)
+			}
+		}
+	}
+}
+
+func xmlAttrValue(attrs []xml.Attr, local string) string {
+	for _, attr := range attrs {
+		if strings.EqualFold(attr.Name.Local, local) {
+			return strings.TrimSpace(attr.Value)
+		}
+	}
+	return ""
+}
+
+func isLocalAssetRef(ref string) bool {
+	ref = strings.TrimSpace(ref)
+	if ref == "" || strings.HasPrefix(ref, "#") {
+		return false
+	}
+	lower := strings.ToLower(ref)
+	return !strings.HasPrefix(lower, "http://") &&
+		!strings.HasPrefix(lower, "https://") &&
+		!strings.HasPrefix(lower, "data:")
 }

--- a/epub_test.go
+++ b/epub_test.go
@@ -62,11 +62,41 @@ func TestAddPageWithAssetSharesID(t *testing.T) {
 	if page.AssetID != asset.ID {
 		t.Fatalf("page asset id (%s) and asset id (%s) must match", page.AssetID, asset.ID)
 	}
+	if page.Href != "item/image/p-001.png" {
+		t.Fatalf("unexpected page href: %s", page.Href)
+	}
 	if page.Spread != "left" {
 		t.Fatalf("unexpected spread: %s", page.Spread)
 	}
 	if page.Width != 1 || page.Height != 1 {
 		t.Fatalf("unexpected viewport: %dx%d", page.Width, page.Height)
+	}
+}
+
+func TestDocumentExtractReferencedImagesFromSpineDirectImage(t *testing.T) {
+	doc := &Document{}
+	pngBytes := testPNGBytes()
+
+	page, asset, err := doc.AddPageWithAsset(bytes.NewReader(pngBytes), int64(len(pngBytes)), "right")
+	if err != nil {
+		t.Fatalf("AddPageWithAsset returned error: %v", err)
+	}
+
+	refs, err := doc.ExtractReferencedImagesFromSpine()
+	if err != nil {
+		t.Fatalf("ExtractReferencedImagesFromSpine returned error: %v", err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("unexpected refs len: %d", len(refs))
+	}
+	if refs[0].Page != page {
+		t.Fatal("expected page pointer to be preserved")
+	}
+	if refs[0].Asset != asset {
+		t.Fatal("expected asset pointer to be preserved")
+	}
+	if refs[0].Href != page.Href {
+		t.Fatalf("unexpected href: %s", refs[0].Href)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add Href to Page and populate it during decode and AddPageWithAsset
- add ExtractReferencedImagesFromSpine to resolve images from direct image pages and XHTML spine items
- update CLI image listing and tests for XHTML spine image references

## Testing
- go test ./...

Closes #12