### PR TITLE
feat: add structured reference inconsistency errors

### DIFF
--- a/compliance.go
+++ b/compliance.go
@@ -20,7 +20,7 @@ func validateCompliance(level ComplianceLevel, files map[string]struct{}, manife
 
 	for href, item := range manifest {
 		if _, ok := files[href]; !ok {
-			return &DecodeError{Path: href, Rule: "manifest-physical-existence", Err: ErrAssetNotFound}
+			return &DecodeError{Path: href, Rule: "manifest-physical-existence", Err: &ErrManifestPhysicalMissing{Href: href}}
 		}
 		if err := validateDirectoryRule(href); err != nil {
 			return err

--- a/compliance_test.go
+++ b/compliance_test.go
@@ -55,4 +55,11 @@ func TestValidateCompliance_MissingPhysicalFile(t *testing.T) {
 	if de.Rule != "manifest-physical-existence" {
 		t.Fatalf("unexpected rule: %s", de.Rule)
 	}
+	var missing *ErrManifestPhysicalMissing
+	if !errors.As(err, &missing) {
+		t.Fatalf("expected ErrManifestPhysicalMissing, got: %v", err)
+	}
+	if missing.Href != "item/image/p-001.jpg" {
+		t.Fatalf("unexpected missing href: %s", missing.Href)
+	}
 }

--- a/decode.go
+++ b/decode.go
@@ -84,7 +84,7 @@ func Decode(r io.ReaderAt, size int64, opts ...DecodeOption) (*Document, error) 
 	for _, item := range pkg.Manifest.Items {
 		zfile, ok := filesByName[item.Href]
 		if !ok {
-			return nil, &DecodeError{Path: item.Href, Rule: "manifest-physical-existence", Err: ErrAssetNotFound}
+			return nil, &DecodeError{Path: item.Href, Rule: "manifest-physical-existence", Err: &ErrManifestPhysicalMissing{Href: item.Href}}
 		}
 		current := zfile
 		asset := &Asset{
@@ -104,7 +104,7 @@ func Decode(r io.ReaderAt, size int64, opts ...DecodeOption) (*Document, error) 
 	for i, ref := range pkg.Spine.Itemrefs {
 		item, ok := manifestByID[ref.IDRef]
 		if !ok {
-			return nil, &DecodeError{Path: opfPath, Rule: "spine-idref", Err: ErrAssetNotFound}
+			return nil, &DecodeError{Path: opfPath, Rule: "spine-idref", Err: &ErrSpineUnknownIDRef{IDRef: ref.IDRef}}
 		}
 		page := &Page{Order: i, AssetID: item.ID, Href: item.Href, Spread: spreadFromProperties(ref.Properties)}
 		if doc.IsPrePaginated() && strings.Contains(item.MediaType, "xhtml") {
@@ -190,7 +190,7 @@ func readPackageXML(files map[string]*zip.File, opfPath string) (*packageXML, er
 func readViewport(files map[string]*zip.File, href string) (int, int, error) {
 	f, ok := files[href]
 	if !ok {
-		return 0, 0, &DecodeError{Path: href, Rule: "viewport-file", Err: ErrAssetNotFound}
+		return 0, 0, &DecodeError{Path: href, Rule: "viewport-file", Err: &ErrManifestPhysicalMissing{Href: href}}
 	}
 	rc, err := f.Open()
 	if err != nil {

--- a/decode_test.go
+++ b/decode_test.go
@@ -115,12 +115,61 @@ type minimalEPUBConfig struct {
 	withViewport     bool
 	imageHref        string
 	embeddedImageSrc string
+	spineIDRef       string
+	omitImageFile    bool
+}
+
+func TestDecode_MissingManifestPhysicalFileStructuredError(t *testing.T) {
+	epubData := makeMinimalEPUB(t, minimalEPUBConfig{mimetypeFirst: true, omitImageFile: true})
+	_, err := Decode(bytes.NewReader(epubData), int64(len(epubData)))
+	if err == nil {
+		t.Fatal("expected manifest-physical-existence error")
+	}
+	var de *DecodeError
+	if !errors.As(err, &de) {
+		t.Fatalf("expected DecodeError, got: %T", err)
+	}
+	if de.Rule != "manifest-physical-existence" {
+		t.Fatalf("unexpected rule: %s", de.Rule)
+	}
+	var missing *ErrManifestPhysicalMissing
+	if !errors.As(err, &missing) {
+		t.Fatalf("expected ErrManifestPhysicalMissing, got: %v", err)
+	}
+	if missing.Href != "item/image/p-001.jpg" {
+		t.Fatalf("unexpected missing href: %s", missing.Href)
+	}
+}
+
+func TestDecode_UnknownSpineIDRefStructuredError(t *testing.T) {
+	epubData := makeMinimalEPUB(t, minimalEPUBConfig{mimetypeFirst: true, spineIDRef: "missing-item"})
+	_, err := Decode(bytes.NewReader(epubData), int64(len(epubData)))
+	if err == nil {
+		t.Fatal("expected spine-idref error")
+	}
+	var de *DecodeError
+	if !errors.As(err, &de) {
+		t.Fatalf("expected DecodeError, got: %T", err)
+	}
+	if de.Rule != "spine-idref" {
+		t.Fatalf("unexpected rule: %s", de.Rule)
+	}
+	var unknown *ErrSpineUnknownIDRef
+	if !errors.As(err, &unknown) {
+		t.Fatalf("expected ErrSpineUnknownIDRef, got: %v", err)
+	}
+	if unknown.IDRef != "missing-item" {
+		t.Fatalf("unexpected missing idref: %s", unknown.IDRef)
+	}
 }
 
 func makeMinimalEPUB(t *testing.T, cfg minimalEPUBConfig) []byte {
 	t.Helper()
 	if cfg.imageHref == "" {
 		cfg.imageHref = "item/image/p-001.jpg"
+	}
+	if cfg.spineIDRef == "" {
+		cfg.spineIDRef = "xhtml-1"
 	}
 	manifestImageHref := strings.TrimPrefix(cfg.imageHref, "item/")
 	if !cfg.mimetypeFirst && cfg.mimetypeDeflate {
@@ -161,7 +210,7 @@ func makeMinimalEPUB(t *testing.T, cfg minimalEPUBConfig) []byte {
 		<item id="p-001" href="` + manifestImageHref + `" media-type="image/jpeg"/>
   </manifest>
   <spine page-progression-direction="rtl">
-    <itemref idref="xhtml-1" properties="page-spread-right"/>
+	    <itemref idref="` + cfg.spineIDRef + `" properties="page-spread-right"/>
   </spine>
 </package>`
 
@@ -220,10 +269,12 @@ func makeMinimalEPUB(t *testing.T, cfg minimalEPUBConfig) []byte {
 	} else if _, err := w.Write([]byte(xhtml)); err != nil {
 		t.Fatalf("write xhtml: %v", err)
 	}
-	if w, err := zw.Create(cfg.imageHref); err != nil {
-		t.Fatalf("create image: %v", err)
-	} else if _, err := w.Write([]byte("fake-jpeg")); err != nil {
-		t.Fatalf("write image: %v", err)
+	if !cfg.omitImageFile {
+		if w, err := zw.Create(cfg.imageHref); err != nil {
+			t.Fatalf("create image: %v", err)
+		} else if _, err := w.Write([]byte("fake-jpeg")); err != nil {
+			t.Fatalf("write image: %v", err)
+		}
 	}
 
 	if err := zw.Close(); err != nil {

--- a/errors.go
+++ b/errors.go
@@ -22,8 +22,8 @@ var (
 	ErrSpineMissing = errors.New("OPF spine is missing")
 	// ErrInvalidViewport is returned when viewport meta cannot be parsed.
 	ErrInvalidViewport = errors.New("invalid viewport meta")
-	// ErrAssetNotFound is returned when an itemref references unknown manifest item.
-	ErrAssetNotFound = errors.New("spine itemref references unknown manifest item")
+	// ErrAssetNotFound is returned when an asset cannot be resolved from the current document.
+	ErrAssetNotFound = errors.New("asset not found")
 	// ErrNilAsset is returned when asset receiver is nil.
 	ErrNilAsset = errors.New("asset is nil")
 	// ErrNilAssetOpen is returned when asset stream function is nil.
@@ -56,6 +56,40 @@ var (
 	errInvalidImageNaming     = errors.New("image path must follow item/image/p-000.(jpg|png) format")
 	errInvalidDirectoryLayout = errors.New("asset path must be under item/xhtml, item/image, or item/style")
 )
+
+// ErrSpineUnknownIDRef is returned when a spine itemref points to an unknown manifest ID.
+type ErrSpineUnknownIDRef struct {
+	IDRef string
+}
+
+func (e *ErrSpineUnknownIDRef) Error() string {
+	if e == nil || e.IDRef == "" {
+		return "spine itemref references unknown manifest id"
+	}
+	return fmt.Sprintf("spine itemref references unknown manifest id %q", e.IDRef)
+}
+
+func (e *ErrSpineUnknownIDRef) Is(target error) bool {
+	_, ok := target.(*ErrSpineUnknownIDRef)
+	return ok
+}
+
+// ErrManifestPhysicalMissing is returned when a manifest item href does not exist in the ZIP.
+type ErrManifestPhysicalMissing struct {
+	Href string
+}
+
+func (e *ErrManifestPhysicalMissing) Error() string {
+	if e == nil || e.Href == "" {
+		return "manifest item href does not exist in ZIP"
+	}
+	return fmt.Sprintf("manifest item href %q does not exist in ZIP", e.Href)
+}
+
+func (e *ErrManifestPhysicalMissing) Is(target error) bool {
+	_, ok := target.(*ErrManifestPhysicalMissing)
+	return ok
+}
 
 // DecodeError represents an error that occurred during the decoding of an EPUB file, including the path where the error occurred and the underlying error.
 type DecodeError struct {

--- a/errors_example_test.go
+++ b/errors_example_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package epub
+
+import (
+	"archive/zip"
+	"bytes"
+	"errors"
+	"fmt"
+)
+
+func ExampleDecode_structuredErrors() {
+	epubData := minimalEPUBMissingAssetExample()
+
+	_, err := Decode(bytes.NewReader(epubData), int64(len(epubData)))
+	if err == nil {
+		fmt.Println("ok")
+		return
+	}
+
+	var missing *ErrManifestPhysicalMissing
+	if errors.As(err, &missing) {
+		fmt.Println("missing", missing.Href)
+	}
+
+	// Output:
+	// missing item/image/p-001.jpg
+}
+
+func minimalEPUBMissingAssetExample() []byte {
+	container := `<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="item/standard.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>`
+
+	opf := `<?xml version="1.0" encoding="UTF-8"?>
+<package version="3.0" xmlns="http://www.idpf.org/2007/opf">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Test Book</dc:title>
+  </metadata>
+  <manifest>
+    <item id="xhtml-1" href="xhtml/p-001.xhtml" media-type="application/xhtml+xml"/>
+    <item id="p-001" href="image/p-001.jpg" media-type="image/jpeg"/>
+  </manifest>
+  <spine page-progression-direction="rtl">
+    <itemref idref="xhtml-1" properties="page-spread-right"/>
+  </spine>
+</package>`
+
+	xhtml := `<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><head><title>p1</title></head><body><p>hello</p></body></html>`
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	w, err := zw.CreateHeader(&zip.FileHeader{Name: "mimetype", Method: zip.Store})
+	if err != nil {
+		panic(err)
+	}
+	if _, err := w.Write([]byte(mimeTypeValue)); err != nil {
+		panic(err)
+	}
+	for _, file := range []struct {
+		name string
+		body string
+	}{
+		{name: "META-INF/container.xml", body: container},
+		{name: "item/standard.opf", body: opf},
+		{name: "item/xhtml/p-001.xhtml", body: xhtml},
+	} {
+		w, err := zw.Create(file.name)
+		if err != nil {
+			panic(err)
+		}
+		if _, err := w.Write([]byte(file.body)); err != nil {
+			panic(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		panic(err)
+	}
+	return buf.Bytes()
+}


### PR DESCRIPTION
## Summary
- add structured error types for spine idref mismatches and missing manifest files in ZIP
- return the new errors from decode and compliance validation paths
- add tests and a runnable example covering errors.As usage

## Testing
- go test ./...