### PR TITLE
feat(decode): collect non-fatal warnings during EPUB decode

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"path"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -63,13 +64,36 @@ func Decode(r io.ReaderAt, size int64, opts ...DecodeOption) (*Document, error) 
 
 	manifestByID := make(map[string]manifestItem, len(pkg.Manifest.Items))
 	manifestByHref := make(map[string]manifestItem, len(pkg.Manifest.Items))
+	normalizedManifest := make([]manifestItem, 0, len(pkg.Manifest.Items))
+	warnings := make([]string, 0)
+	warningSet := make(map[string]struct{})
+	addWarning := func(msg string) {
+		msg = strings.TrimSpace(msg)
+		if msg == "" {
+			return
+		}
+		if _, exists := warningSet[msg]; exists {
+			return
+		}
+		warningSet[msg] = struct{}{}
+		warnings = append(warnings, msg)
+	}
 	opfDir := path.Dir(opfPath)
 	for i, it := range pkg.Manifest.Items {
 		href := cleanOPFRef(opfDir, it.Href)
 		it.Href = href
 		pkg.Manifest.Items[i] = it
+		if prev, exists := manifestByID[it.ID]; exists {
+			addWarning(fmt.Sprintf("duplicate manifest id %q: href %q ignored (already defined as %q)", it.ID, it.Href, prev.Href))
+			continue
+		}
+		if prev, exists := manifestByHref[href]; exists {
+			addWarning(fmt.Sprintf("duplicate manifest href %q: id %q ignored (already defined as %q)", it.Href, it.ID, prev.ID))
+			continue
+		}
 		manifestByID[it.ID] = it
 		manifestByHref[href] = it
+		normalizedManifest = append(normalizedManifest, it)
 	}
 
 	if err := validateCompliance(cfg.compliance, fileSet, manifestByHref); err != nil {
@@ -82,10 +106,11 @@ func Decode(r io.ReaderAt, size int64, opts ...DecodeOption) (*Document, error) 
 		Direction:  normalizeDirection(pkg.Spine.PageProgressionDirection),
 		Layout:     parseLayoutType(pkg.Metadata.Meta),
 		Pages:      make([]*Page, 0, len(pkg.Spine.Itemrefs)),
-		Assets:     make(map[string]*Asset, len(pkg.Manifest.Items)),
+		Assets:     make(map[string]*Asset, len(normalizedManifest)),
+		Warnings:   make([]string, 0),
 	}
 
-	for _, item := range pkg.Manifest.Items {
+	for _, item := range normalizedManifest {
 		zfile, ok := filesByName[item.Href]
 		if !ok {
 			return nil, &DecodeError{Path: item.Href, Rule: "manifest-physical-existence", Err: &ErrManifestPhysicalMissing{Href: item.Href}}
@@ -121,6 +146,27 @@ func Decode(r io.ReaderAt, size int64, opts ...DecodeOption) (*Document, error) 
 		}
 		doc.Pages = append(doc.Pages, page)
 	}
+
+	reservedPaths := map[string]struct{}{
+		"mimetype":               {},
+		"META-INF/container.xml": {},
+		opfPath:                  {},
+	}
+	zipNames := make([]string, 0, len(fileSet))
+	for name := range fileSet {
+		zipNames = append(zipNames, name)
+	}
+	sort.Strings(zipNames)
+	for _, name := range zipNames {
+		if _, isReserved := reservedPaths[name]; isReserved {
+			continue
+		}
+		if _, exists := manifestByHref[name]; !exists {
+			addWarning(fmt.Sprintf("archive file %q is not declared in manifest", name))
+		}
+	}
+
+	doc.Warnings = warnings
 
 	return doc, nil
 }

--- a/decode_test.go
+++ b/decode_test.go
@@ -108,15 +108,48 @@ func TestDecode_EBPAJImageNamingViolation(t *testing.T) {
 	}
 }
 
+func TestDecode_WarningsCollected(t *testing.T) {
+	epubData := makeMinimalEPUB(t, minimalEPUBConfig{
+		mimetypeFirst:       true,
+		duplicateManifestID: true,
+		extraArchiveFile:    "item/image/orphan.jpg",
+	})
+	doc, err := Decode(bytes.NewReader(epubData), int64(len(epubData)))
+	if err != nil {
+		t.Fatalf("Decode failed: %v", err)
+	}
+	if len(doc.Warnings) == 0 {
+		t.Fatal("expected warnings to be collected")
+	}
+
+	if !containsWarning(doc.Warnings, "duplicate manifest id \"p-001\"") {
+		t.Fatalf("expected duplicate manifest id warning, got: %#v", doc.Warnings)
+	}
+	if !containsWarning(doc.Warnings, "archive file \"item/image/orphan.jpg\" is not declared in manifest") {
+		t.Fatalf("expected orphan file warning, got: %#v", doc.Warnings)
+	}
+}
+
 type minimalEPUBConfig struct {
-	mimetypeFirst    bool
-	mimetypeDeflate  bool
-	prePaginated     bool
-	withViewport     bool
-	imageHref        string
-	embeddedImageSrc string
-	spineIDRef       string
-	omitImageFile    bool
+	mimetypeFirst       bool
+	mimetypeDeflate     bool
+	prePaginated        bool
+	withViewport        bool
+	imageHref           string
+	embeddedImageSrc    string
+	spineIDRef          string
+	omitImageFile       bool
+	duplicateManifestID bool
+	extraArchiveFile    string
+}
+
+func containsWarning(warnings []string, want string) bool {
+	for _, w := range warnings {
+		if strings.Contains(w, want) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestDecode_MissingManifestPhysicalFileStructuredError(t *testing.T) {
@@ -267,6 +300,12 @@ func makeMinimalEPUB(t *testing.T, cfg minimalEPUBConfig) []byte {
 		layout = "pre-paginated"
 	}
 
+	extraManifestItem := ""
+	if cfg.duplicateManifestID {
+		extraManifestItem = `
+		<item id="p-001" href="image/p-dup.jpg" media-type="image/jpeg"/>`
+	}
+
 	xhtml := `<?xml version="1.0" encoding="UTF-8"?>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
@@ -294,6 +333,7 @@ func makeMinimalEPUB(t *testing.T, cfg minimalEPUBConfig) []byte {
   <manifest>
 		<item id="xhtml-1" href="xhtml/p-001.xhtml" media-type="application/xhtml+xml"/>
 		<item id="p-001" href="` + manifestImageHref + `" media-type="image/jpeg"/>
+		` + extraManifestItem + `
   </manifest>
   <spine page-progression-direction="rtl">
 	    <itemref idref="` + cfg.spineIDRef + `" properties="page-spread-right"/>
@@ -360,6 +400,20 @@ func makeMinimalEPUB(t *testing.T, cfg minimalEPUBConfig) []byte {
 			t.Fatalf("create image: %v", err)
 		} else if _, err := w.Write([]byte("fake-jpeg")); err != nil {
 			t.Fatalf("write image: %v", err)
+		}
+	}
+	if cfg.duplicateManifestID {
+		if w, err := zw.Create("item/image/p-dup.jpg"); err != nil {
+			t.Fatalf("create duplicate image: %v", err)
+		} else if _, err := w.Write([]byte("fake-jpeg-dup")); err != nil {
+			t.Fatalf("write duplicate image: %v", err)
+		}
+	}
+	if cfg.extraArchiveFile != "" {
+		if w, err := zw.Create(cfg.extraArchiveFile); err != nil {
+			t.Fatalf("create extra archive file: %v", err)
+		} else if _, err := w.Write([]byte("orphan")); err != nil {
+			t.Fatalf("write extra archive file: %v", err)
 		}
 	}
 

--- a/epub.go
+++ b/epub.go
@@ -31,6 +31,7 @@ type Document struct {
 	Layout     LayoutType
 	Pages      []*Page
 	Assets     map[string]*Asset
+	Warnings   []string
 }
 
 // LayoutType represents rendition:layout in OPF metadata.


### PR DESCRIPTION
## Summary
- add a warnings collection field to the public Document model
- collect non-fatal decode anomalies instead of failing immediately for:
  - duplicate manifest IDs
  - duplicate manifest hrefs
  - archive files not declared in manifest
- add decode tests to verify warning collection behavior

## Validation
- gofmt -l .
- go test ./...

Closes #11
