### PR TITLE
feat: support advanced metadata for commercial compliance

### DIFF
--- a/cmd/epub/main.go
+++ b/cmd/epub/main.go
@@ -77,7 +77,7 @@ func runInspect(args []string) error {
 		return err
 	}
 
-	fmt.Printf("Title: %s\n", doc.Title)
+	fmt.Printf("Title: %s\n", doc.Metadata.Title)
 	fmt.Printf("Direction: %s\n", doc.Direction)
 	fmt.Printf("Layout: %s\n", doc.Layout.String())
 	fmt.Printf("Pages: %d\n", len(doc.Pages))
@@ -268,7 +268,7 @@ func runBuildFromImages(args []string) error {
 	}
 
 	doc := &epub.Document{
-		Title:     strings.TrimSpace(*title),
+		Metadata:  epub.Metadata{Title: strings.TrimSpace(*title)},
 		Direction: directionNorm,
 		Layout:    layoutType,
 		Pages:     make([]*epub.Page, 0, len(imagePaths)),

--- a/decode.go
+++ b/decode.go
@@ -101,9 +101,27 @@ func Decode(r io.ReaderAt, size int64, opts ...DecodeOption) (*Document, error) 
 		return nil, err
 	}
 
+	title, titleID := primaryDCValue(pkg.Metadata.Titles)
+	identifier, identifierID := primaryIdentifier(pkg.Metadata.Identifiers, pkg.UniqueIdentifier)
+	fileAsByRefines := parseFileAsByRefines(pkg.Metadata.Meta)
+
+	titleFileAs := ""
+	if titleID != "" {
+		titleFileAs = fileAsByRefines["#"+titleID]
+	}
+
 	doc := &Document{
-		Title:      strings.TrimSpace(pkg.Metadata.Title),
-		Identifier: strings.TrimSpace(pkg.Metadata.Identifier),
+		Metadata: Metadata{
+			Title:             title,
+			TitleFileAs:       titleFileAs,
+			Identifier:        identifier,
+			IdentifierID:      identifierID,
+			Creators:          parseCreators(pkg.Metadata.Creators, fileAsByRefines),
+			EBPAJGuideVersion: parseMetaValueByProperty(pkg.Metadata.Meta, "ebpaj:guide-version"),
+			KADOKAWAVersion:   parseMetaValueByProperty(pkg.Metadata.Meta, "kadokawa:version"),
+		},
+		Title:      title,
+		Identifier: identifier,
 		Direction:  normalizeDirection(pkg.Spine.PageProgressionDirection),
 		Layout:     parseLayoutType(pkg.Metadata.Meta),
 		Pages:      make([]*Page, 0, len(pkg.Spine.Itemrefs)),
@@ -334,6 +352,91 @@ func parseLayoutType(meta []metadataMeta) LayoutType {
 		}
 	}
 	return LayoutUnknown
+}
+
+func parseMetaValueByProperty(meta []metadataMeta, property string) string {
+	for _, m := range meta {
+		if strings.EqualFold(strings.TrimSpace(m.Property), property) {
+			v := strings.TrimSpace(m.Value)
+			if v == "" {
+				v = strings.TrimSpace(m.Content)
+			}
+			return v
+		}
+	}
+	return ""
+}
+
+func parseFileAsByRefines(meta []metadataMeta) map[string]string {
+	result := make(map[string]string)
+	for _, m := range meta {
+		if !strings.EqualFold(strings.TrimSpace(m.Property), "file-as") {
+			continue
+		}
+		refines := strings.TrimSpace(m.Refines)
+		if refines == "" {
+			continue
+		}
+		v := strings.TrimSpace(m.Value)
+		if v == "" {
+			v = strings.TrimSpace(m.Content)
+		}
+		if v == "" {
+			continue
+		}
+		result[refines] = v
+	}
+	return result
+}
+
+func parseCreators(creators []dcElement, fileAsByRefines map[string]string) []Creator {
+	result := make([]Creator, 0, len(creators))
+	for _, creator := range creators {
+		name := strings.TrimSpace(creator.Value)
+		if name == "" {
+			continue
+		}
+		ref := ""
+		if id := strings.TrimSpace(creator.ID); id != "" {
+			ref = "#" + id
+		}
+		result = append(result, Creator{Name: name, FileAs: fileAsByRefines[ref]})
+	}
+	return result
+}
+
+func primaryDCValue(values []dcElement) (string, string) {
+	for _, v := range values {
+		value := strings.TrimSpace(v.Value)
+		if value != "" {
+			return value, strings.TrimSpace(v.ID)
+		}
+	}
+	return "", ""
+}
+
+func primaryIdentifier(values []dcElement, preferredID string) (string, string) {
+	preferredID = strings.TrimSpace(preferredID)
+	if preferredID != "" {
+		for _, v := range values {
+			id := strings.TrimSpace(v.ID)
+			if id != preferredID {
+				continue
+			}
+			value := strings.TrimSpace(v.Value)
+			if value != "" {
+				return value, id
+			}
+		}
+	}
+
+	for _, v := range values {
+		value := strings.TrimSpace(v.Value)
+		if value != "" {
+			return value, strings.TrimSpace(v.ID)
+		}
+	}
+	return "", preferredID
 }
 
 func normalizeDirection(v string) string {

--- a/decode_test.go
+++ b/decode_test.go
@@ -16,8 +16,11 @@ func TestDecode_MinimalValid(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Decode failed: %v", err)
 	}
+	if doc.Metadata.Title != "Test Book" {
+		t.Fatalf("unexpected title: %s", doc.Metadata.Title)
+	}
 	if doc.Title != "Test Book" {
-		t.Fatalf("unexpected title: %s", doc.Title)
+		t.Fatalf("unexpected legacy title: %s", doc.Title)
 	}
 	if doc.Direction != "rtl" {
 		t.Fatalf("unexpected direction: %s", doc.Direction)
@@ -127,6 +130,94 @@ func TestDecode_WarningsCollected(t *testing.T) {
 	}
 	if !containsWarning(doc.Warnings, "archive file \"item/image/orphan.jpg\" is not declared in manifest") {
 		t.Fatalf("expected orphan file warning, got: %#v", doc.Warnings)
+	}
+}
+
+func TestDecode_Issue4AdvancedMetadata(t *testing.T) {
+	opf := `<?xml version="1.0" encoding="UTF-8"?>
+<package version="3.0" xmlns="http://www.idpf.org/2007/opf" unique-identifier="bw-ecode" prefix="rendition: http://www.idpf.org/vocab/rendition/# dcterms: http://purl.org/dc/terms/ ebpaj: https://www.ebpaj.jp/ kadokawa: https://www.kadokawa.co.jp/">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title id="title">Main Title</dc:title>
+    <dc:identifier id="bw-ecode">12345678901234567890</dc:identifier>
+    <dc:creator id="creator-1">Author A</dc:creator>
+    <meta property="file-as" refines="#title">Main Title Yomi</meta>
+    <meta property="file-as" refines="#creator-1">Author A Yomi</meta>
+    <meta property="rendition:layout">pre-paginated</meta>
+    <meta property="dcterms:modified">2026-04-02T12:34:56Z</meta>
+    <meta property="ebpaj:guide-version">1.2.0</meta>
+    <meta property="kadokawa:version">2.0</meta>
+  </metadata>
+  <manifest>
+    <item id="xhtml-1" href="xhtml/p-001.xhtml" media-type="application/xhtml+xml"/>
+    <item id="p-001" href="image/p-001.jpg" media-type="image/jpeg"/>
+  </manifest>
+  <spine page-progression-direction="rtl">
+    <itemref idref="xhtml-1" properties="page-spread-right"/>
+  </spine>
+</package>`
+
+	container := `<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="item/standard.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>`
+	xhtml := `<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><head><title>p1</title><meta name="viewport" content="width=1200,height=1600"/></head><body><p>hello</p></body></html>`
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	write := func(name string, method uint16, body string) {
+		t.Helper()
+		w, err := zw.CreateHeader(&zip.FileHeader{Name: name, Method: method})
+		if err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+		if _, err := w.Write([]byte(body)); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	write("mimetype", zip.Store, "application/epub+zip")
+	write("META-INF/container.xml", zip.Deflate, container)
+	write("item/standard.opf", zip.Deflate, opf)
+	write("item/xhtml/p-001.xhtml", zip.Deflate, xhtml)
+	write("item/image/p-001.jpg", zip.Deflate, "fake-jpeg")
+
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+
+	doc, err := Decode(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	if err != nil {
+		t.Fatalf("Decode failed: %v", err)
+	}
+	if doc.Metadata.IdentifierID != "bw-ecode" {
+		t.Fatalf("unexpected metadata identifier id: %s", doc.Metadata.IdentifierID)
+	}
+	if doc.Metadata.Identifier != "12345678901234567890" {
+		t.Fatalf("unexpected metadata identifier: %s", doc.Metadata.Identifier)
+	}
+	if doc.Identifier != "12345678901234567890" {
+		t.Fatalf("unexpected legacy identifier: %s", doc.Identifier)
+	}
+	if doc.Metadata.Title != "Main Title" {
+		t.Fatalf("unexpected metadata title: %s", doc.Metadata.Title)
+	}
+	if doc.Metadata.TitleFileAs != "Main Title Yomi" {
+		t.Fatalf("unexpected metadata title file-as: %s", doc.Metadata.TitleFileAs)
+	}
+	if len(doc.Metadata.Creators) != 1 {
+		t.Fatalf("unexpected metadata creators len: %d", len(doc.Metadata.Creators))
+	}
+	if doc.Metadata.Creators[0].Name != "Author A" || doc.Metadata.Creators[0].FileAs != "Author A Yomi" {
+		t.Fatalf("unexpected metadata creator: %#v", doc.Metadata.Creators[0])
+	}
+	if doc.Metadata.EBPAJGuideVersion != "1.2.0" {
+		t.Fatalf("unexpected metadata ebpaj guide version: %s", doc.Metadata.EBPAJGuideVersion)
+	}
+	if doc.Metadata.KADOKAWAVersion != "2.0" {
+		t.Fatalf("unexpected metadata kadokawa version: %s", doc.Metadata.KADOKAWAVersion)
 	}
 }
 

--- a/doc.go
+++ b/doc.go
@@ -30,7 +30,7 @@
 //	img, _ := os.Open("./p-001.jpg")
 //	defer img.Close()
 //	st, _ := img.Stat()
-//	doc := &epub.Document{Title: "Demo", Direction: "rtl", Layout: epub.LayoutPrePaginated}
+//	doc := &epub.Document{Metadata: epub.Metadata{Title: "Demo"}, Direction: "rtl", Layout: epub.LayoutPrePaginated}
 //	_, _, _ = doc.AddPageWithAsset(img, st.Size(), "right")
 //	_ = epub.Encode(io.Discard, doc)
 package epub

--- a/encode.go
+++ b/encode.go
@@ -11,6 +11,12 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
+)
+
+const (
+	defaultEBPAJGuideVersion = "1.1.3"
+	defaultKADOKAWAVersion   = "1.0"
 )
 
 // EncodeOption mutates encode behavior.
@@ -76,13 +82,16 @@ func writeContainer(zw *zip.Writer) error {
 }
 
 func writePackageAndAssets(zw *zip.Writer, doc *Document, cfg encodeConfig) error {
+	metadata := doc.effectiveMetadata()
+
 	assetPaths := make([]string, 0, len(doc.Assets))
 	for p := range doc.Assets {
 		assetPaths = append(assetPaths, p)
 	}
 	sort.Strings(assetPaths)
 
-	identifier := normalizeIdentifier(doc.Identifier)
+	identifier := normalizeIdentifier(metadata.Identifier)
+	identifierID := normalizeIdentifierID(metadata.IdentifierID)
 	navHref := "nav.xhtml"
 
 	manifestItems := make([]string, 0, len(assetPaths))
@@ -119,12 +128,37 @@ func writePackageAndAssets(zw *zip.Writer, doc *Document, cfg encodeConfig) erro
 		spineTOC = ` toc="ncx"`
 	}
 
+	metadataEntries := []string{
+		fmt.Sprintf(`<dc:title id="title">%s</dc:title>`, xmlEscape(metadata.Title)),
+		fmt.Sprintf(`<dc:identifier id=%q>%s</dc:identifier>`, xmlEscape(identifierID), xmlEscape(identifier)),
+	}
+
+	if v := strings.TrimSpace(metadata.TitleFileAs); v != "" {
+		metadataEntries = append(metadataEntries, fmt.Sprintf(`<meta property="file-as" refines="#title">%s</meta>`, xmlEscape(v)))
+	}
+	for i, creator := range metadata.Creators {
+		name := strings.TrimSpace(creator.Name)
+		if name == "" {
+			continue
+		}
+		creatorID := fmt.Sprintf("creator-%d", i+1)
+		metadataEntries = append(metadataEntries, fmt.Sprintf(`<dc:creator id=%q>%s</dc:creator>`, xmlEscape(creatorID), xmlEscape(name)))
+		if v := strings.TrimSpace(creator.FileAs); v != "" {
+			metadataEntries = append(metadataEntries, fmt.Sprintf(`<meta property="file-as" refines=%q>%s</meta>`, xmlEscape("#"+creatorID), xmlEscape(v)))
+		}
+	}
+
+	metadataEntries = append(metadataEntries,
+		fmt.Sprintf(`<meta property="rendition:layout">%s</meta>`, xmlEscape(rLayout)),
+		fmt.Sprintf(`<meta property="dcterms:modified">%s</meta>`, xmlEscape(formatW3CTime(time.Now()))),
+		fmt.Sprintf(`<meta property="ebpaj:guide-version">%s</meta>`, xmlEscape(normalizeSpecVersion(metadata.EBPAJGuideVersion, defaultEBPAJGuideVersion))),
+		fmt.Sprintf(`<meta property="kadokawa:version">%s</meta>`, xmlEscape(normalizeSpecVersion(metadata.KADOKAWAVersion, defaultKADOKAWAVersion))),
+	)
+
 	opf := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
-<package version="3.0" xmlns="http://www.idpf.org/2007/opf" unique-identifier="pub-id">
+<package version="3.0" xmlns="http://www.idpf.org/2007/opf" unique-identifier=%q prefix="rendition: http://www.idpf.org/vocab/rendition/# dcterms: http://purl.org/dc/terms/ ebpaj: https://www.ebpaj.jp/ kadokawa: https://www.kadokawa.co.jp/">
   <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-    <dc:title>%s</dc:title>
-    <dc:identifier id="pub-id">%s</dc:identifier>
-    <meta property="rendition:layout">%s</meta>
+    %s
   </metadata>
   <manifest>
     %s
@@ -132,7 +166,7 @@ func writePackageAndAssets(zw *zip.Writer, doc *Document, cfg encodeConfig) erro
   <spine page-progression-direction=%q%s>
     %s
   </spine>
-</package>`, xmlEscape(doc.Title), xmlEscape(identifier), rLayout, strings.Join(manifestItems, "\n    "), xmlEscape(normalizeDirection(doc.Direction)), spineTOC, strings.Join(spineItems, "\n    "))
+</package>`, xmlEscape(identifierID), strings.Join(metadataEntries, "\n    "), strings.Join(manifestItems, "\n    "), xmlEscape(normalizeDirection(doc.Direction)), spineTOC, strings.Join(spineItems, "\n    "))
 
 	w, err := zw.Create("item/standard.opf")
 	if err != nil {
@@ -216,6 +250,26 @@ func normalizeIdentifier(v string) string {
 	return v
 }
 
+func normalizeIdentifierID(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return "pub-id"
+	}
+	return v
+}
+
+func normalizeSpecVersion(v, fallback string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return fallback
+	}
+	return v
+}
+
+func formatW3CTime(t time.Time) string {
+	return t.UTC().Format("2006-01-02T15:04:05Z")
+}
+
 func buildNavigationDocument(doc *Document, navHref string) (string, error) {
 	tocItems := make([]string, 0, len(doc.Pages))
 	for i, pg := range doc.Pages {
@@ -276,6 +330,8 @@ func buildNavigationDocument(doc *Document, navHref string) (string, error) {
 }
 
 func buildLegacyNCX(doc *Document, identifier string) string {
+	metadata := doc.effectiveMetadata()
+
 	navPoints := make([]string, 0, len(doc.Pages))
 	for i, pg := range doc.Pages {
 		href := strings.TrimSpace(pg.Href)
@@ -298,5 +354,5 @@ func buildLegacyNCX(doc *Document, identifier string) string {
   <navMap>
     %s
   </navMap>
-</ncx>`, xmlEscape(identifier), xmlEscape(doc.Title), strings.Join(navPoints, "\n    "))
+</ncx>`, xmlEscape(identifier), xmlEscape(metadata.Title), strings.Join(navPoints, "\n    "))
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -6,13 +6,14 @@ import (
 	"archive/zip"
 	"bytes"
 	"io"
+	"regexp"
 	"strings"
 	"testing"
 )
 
 func TestEncode_MimetypeFirstStored(t *testing.T) {
 	doc := &Document{
-		Title:     "Demo",
+		Metadata:  Metadata{Title: "Demo"},
 		Direction: "rtl",
 		Layout:    LayoutPrePaginated,
 		Pages: []*Page{{
@@ -53,7 +54,7 @@ func TestEncode_MimetypeFirstStored(t *testing.T) {
 
 func TestEncodeDecode_RoundTripBasic(t *testing.T) {
 	doc := &Document{
-		Title:     "RoundTrip",
+		Metadata:  Metadata{Title: "RoundTrip"},
 		Direction: "ltr",
 		Layout:    LayoutPrePaginated,
 	}
@@ -75,8 +76,8 @@ func TestEncodeDecode_RoundTripBasic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Decode failed: %v", err)
 	}
-	if decoded.Title != "RoundTrip" {
-		t.Fatalf("unexpected title: %s", decoded.Title)
+	if decoded.Metadata.Title != "RoundTrip" {
+		t.Fatalf("unexpected title: %s", decoded.Metadata.Title)
 	}
 	if decoded.Layout != LayoutPrePaginated {
 		t.Fatalf("unexpected layout: %v", decoded.Layout)
@@ -91,10 +92,9 @@ func TestEncodeDecode_RoundTripBasic(t *testing.T) {
 
 func TestEncode_GeneratesNavigationDocument(t *testing.T) {
 	doc := &Document{
-		Title:      "Nav Test",
-		Identifier: "E-0001",
-		Direction:  "rtl",
-		Layout:     LayoutPrePaginated,
+		Metadata:  Metadata{Title: "Nav Test", Identifier: "E-0001"},
+		Direction: "rtl",
+		Layout:    LayoutPrePaginated,
 	}
 	png := testPNGBytes()
 	if _, _, err := doc.AddPageWithAsset(bytes.NewReader(png), int64(len(png)), "right"); err != nil {
@@ -125,10 +125,9 @@ func TestEncode_GeneratesNavigationDocument(t *testing.T) {
 
 func TestEncode_WithLegacyTOC_GeneratesNCXWithMatchingUID(t *testing.T) {
 	doc := &Document{
-		Title:      "Legacy TOC",
-		Identifier: "E-2026-0002",
-		Direction:  "ltr",
-		Layout:     LayoutReflowable,
+		Metadata:  Metadata{Title: "Legacy TOC", Identifier: "E-2026-0002"},
+		Direction: "ltr",
+		Layout:    LayoutReflowable,
 	}
 	png := testPNGBytes()
 	if _, _, err := doc.AddPageWithAsset(bytes.NewReader(png), int64(len(png)), "none"); err != nil {
@@ -157,6 +156,57 @@ func TestEncode_WithLegacyTOC_GeneratesNCXWithMatchingUID(t *testing.T) {
 	ncxContent := readZipEntry(t, out.Bytes(), "item/toc.ncx")
 	if !strings.Contains(ncxContent, `<meta name="dtb:uid" content="E-2026-0002"/>`) {
 		t.Fatalf("ncx dtb:uid mismatch: %s", ncxContent)
+	}
+}
+
+func TestEncode_Issue4AdvancedMetadata(t *testing.T) {
+	doc := &Document{
+		Metadata: Metadata{
+			Title:             "Main Title",
+			TitleFileAs:       "Main Title Yomi",
+			IdentifierID:      "bw-ecode",
+			Identifier:        "12345678901234567890",
+			Creators:          []Creator{{Name: "Author A", FileAs: "Author A Yomi"}},
+			EBPAJGuideVersion: "1.2.0",
+			KADOKAWAVersion:   "2.0",
+		},
+		Direction: "rtl",
+		Layout:    LayoutPrePaginated,
+	}
+	png := testPNGBytes()
+	if _, _, err := doc.AddPageWithAsset(bytes.NewReader(png), int64(len(png)), "right"); err != nil {
+		t.Fatalf("AddPageWithAsset failed: %v", err)
+	}
+
+	var out bytes.Buffer
+	if err := Encode(&out, doc); err != nil {
+		t.Fatalf("Encode failed: %v", err)
+	}
+
+	opfContent := readZipEntry(t, out.Bytes(), "item/standard.opf")
+	if !strings.Contains(opfContent, `<package version="3.0" xmlns="http://www.idpf.org/2007/opf" unique-identifier="bw-ecode"`) {
+		t.Fatalf("opf unique-identifier is missing: %s", opfContent)
+	}
+	if !strings.Contains(opfContent, `<dc:identifier id="bw-ecode">12345678901234567890</dc:identifier>`) {
+		t.Fatalf("opf bw-ecode identifier is missing: %s", opfContent)
+	}
+	if !strings.Contains(opfContent, `<meta property="file-as" refines="#title">Main Title Yomi</meta>`) {
+		t.Fatalf("title file-as is missing: %s", opfContent)
+	}
+	if !strings.Contains(opfContent, `<dc:creator id="creator-1">Author A</dc:creator>`) {
+		t.Fatalf("creator is missing: %s", opfContent)
+	}
+	if !strings.Contains(opfContent, `<meta property="file-as" refines="#creator-1">Author A Yomi</meta>`) {
+		t.Fatalf("creator file-as is missing: %s", opfContent)
+	}
+	if !strings.Contains(opfContent, `<meta property="ebpaj:guide-version">1.2.0</meta>`) {
+		t.Fatalf("ebpaj:guide-version is missing: %s", opfContent)
+	}
+	if !strings.Contains(opfContent, `<meta property="kadokawa:version">2.0</meta>`) {
+		t.Fatalf("kadokawa:version is missing: %s", opfContent)
+	}
+	if !regexp.MustCompile(`<meta property="dcterms:modified">[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z</meta>`).MatchString(opfContent) {
+		t.Fatalf("dcterms:modified format is invalid: %s", opfContent)
 	}
 }
 

--- a/epub.go
+++ b/epub.go
@@ -25,13 +25,47 @@ import (
 //
 // Assets uses the manifest href as the map key.
 type Document struct {
-	Title      string
+	Metadata Metadata
+	// Title is kept for backward compatibility. Prefer Metadata.Title for new code.
+	Title string
+	// Identifier is kept for backward compatibility. Prefer Metadata.Identifier for new code.
 	Identifier string
 	Direction  string // "rtl" (right-to-left) or "ltr".
 	Layout     LayoutType
 	Pages      []*Page
 	Assets     map[string]*Asset
 	Warnings   []string
+}
+
+// Metadata represents OPF metadata values used by this package.
+type Metadata struct {
+	Title             string
+	TitleFileAs       string
+	Identifier        string
+	IdentifierID      string
+	Creators          []Creator
+	EBPAJGuideVersion string
+	KADOKAWAVersion   string
+}
+
+// Creator represents a dc:creator entry with optional phonetic sort key.
+type Creator struct {
+	Name   string
+	FileAs string
+}
+
+func (d *Document) effectiveMetadata() Metadata {
+	if d == nil {
+		return Metadata{}
+	}
+	m := d.Metadata
+	if strings.TrimSpace(m.Title) == "" {
+		m.Title = d.Title
+	}
+	if strings.TrimSpace(m.Identifier) == "" {
+		m.Identifier = d.Identifier
+	}
+	return m
 }
 
 // LayoutType represents rendition:layout in OPF metadata.

--- a/epub_example_test.go
+++ b/epub_example_test.go
@@ -28,7 +28,7 @@ func ExampleDocument_AddAsset() {
 
 func ExampleDocument_AddPageWithAsset() {
 	doc := &Document{
-		Title:     "Demo",
+		Metadata:  Metadata{Title: "Demo"},
 		Direction: "rtl",
 		Layout:    LayoutPrePaginated,
 	}

--- a/testdata_test.go
+++ b/testdata_test.go
@@ -44,7 +44,7 @@ func TestTestdata_DecodeAll(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Decode failed: %v", err)
 			}
-			if doc.Title == "" {
+			if doc.Metadata.Title == "" {
 				t.Error("Title is empty")
 			}
 			if len(doc.Pages) == 0 {
@@ -117,7 +117,7 @@ func TestTestdata_DPFJTemplates(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Decode failed: %v", err)
 			}
-			if doc.Title == "" {
+			if doc.Metadata.Title == "" {
 				t.Error("Title is empty")
 			}
 			if doc.Direction != "rtl" {

--- a/xml_types.go
+++ b/xml_types.go
@@ -19,20 +19,28 @@ type containerRootfile struct {
 }
 
 type packageXML struct {
-	XMLName  xml.Name        `xml:"package"`
-	Metadata packageMetadata `xml:"metadata"`
-	Manifest packageManifest `xml:"manifest"`
-	Spine    packageSpine    `xml:"spine"`
+	XMLName          xml.Name        `xml:"package"`
+	UniqueIdentifier string          `xml:"unique-identifier,attr"`
+	Metadata         packageMetadata `xml:"metadata"`
+	Manifest         packageManifest `xml:"manifest"`
+	Spine            packageSpine    `xml:"spine"`
 }
 
 type packageMetadata struct {
-	Title      string         `xml:"title"`
-	Identifier string         `xml:"identifier"`
-	Meta       []metadataMeta `xml:"meta"`
+	Titles      []dcElement    `xml:"title"`
+	Identifiers []dcElement    `xml:"identifier"`
+	Creators    []dcElement    `xml:"creator"`
+	Meta        []metadataMeta `xml:"meta"`
+}
+
+type dcElement struct {
+	ID    string `xml:"id,attr"`
+	Value string `xml:",chardata"`
 }
 
 type metadataMeta struct {
 	Property string `xml:"property,attr"`
+	Refines  string `xml:"refines,attr"`
 	Name     string `xml:"name,attr"`
 	Content  string `xml:"content,attr"`
 	Value    string `xml:",chardata"`


### PR DESCRIPTION
## Summary
- implement issue #4 requirements for commercial metadata compliance
- add support for custom unique identifier id/value (including bw-ecode + 20-digit E-code)
- add file-as metadata for title and creators
- auto-generate dcterms:modified in W3C UTC format
- include ebpaj:guide-version and kadokawa:version metadata
- introduce Metadata struct to group extended metadata while keeping backward compatibility for existing Title/Identifier fields
- update decode/encode/xml mappings and CLI/test fixtures accordingly

## Testing
- go test ./...

Closes #4