### PR TITLE
fix: expect compliance error for sizecheck EPUBs in KADOKAWACompliance test

### DIFF
--- a/testdata_test.go
+++ b/testdata_test.go
@@ -60,10 +60,11 @@ func TestTestdata_KADOKAWACompliance(t *testing.T) {
 		t.Skip("no epub files in testdata/ (see testdata/README.md)")
 	}
 	for _, p := range paths {
-		if !strings.Contains(filepath.Base(p), "kadokawa") {
+		base := filepath.Base(p)
+		if !strings.Contains(base, "kadokawa") {
 			continue
 		}
-		t.Run(filepath.Base(p), func(t *testing.T) {
+		t.Run(base, func(t *testing.T) {
 			f, err := os.Open(p)
 			if err != nil {
 				t.Fatal(err)
@@ -76,6 +77,15 @@ func TestTestdata_KADOKAWACompliance(t *testing.T) {
 			}
 
 			_, err = epub.Decode(f, st.Size(), epub.WithCompliance(epub.LevelKADOKAWA))
+
+			// sizecheck EPUBs intentionally contain oversized images;
+			// they must be rejected by the compliance check.
+			if strings.Contains(base, "sizecheck") {
+				if err == nil {
+					t.Fatal("expected compliance error for sizecheck EPUB, got nil")
+				}
+				return
+			}
 			if err != nil {
 				t.Fatalf("KADOKAWA compliance failed: %v", err)
 			}


### PR DESCRIPTION
## Summary

Fix `TestTestdata_KADOKAWACompliance` failing on `kadokawa-fixed[sizecheck-*]` EPUBs due to pixel count limit exceeded errors.

## Changes

- The sizecheck EPUBs intentionally contain images exceeding the 4,000,000 pixel count limit. The test now expects a compliance error for these files instead of treating it as a test failure.
- All other KADOKAWA EPUBs continue to be expected to pass compliance checks.