### PR TITLE
fix!: wrap AddPageWithAsset images in XHTML spine pages

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -63,8 +63,8 @@ func TestEncodeDecode_RoundTripBasic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AddPageWithAsset failed: %v", err)
 	}
-	if page.AssetID != asset.ID {
-		t.Fatalf("page asset mismatch: %s vs %s", page.AssetID, asset.ID)
+	if page.AssetID == asset.ID {
+		t.Fatalf("page asset should point to wrapper, got image id: %s", page.AssetID)
 	}
 
 	var out bytes.Buffer
@@ -85,7 +85,7 @@ func TestEncodeDecode_RoundTripBasic(t *testing.T) {
 	if len(decoded.Pages) != 1 {
 		t.Fatalf("unexpected pages len: %d", len(decoded.Pages))
 	}
-	if len(decoded.Assets) != 2 {
+	if len(decoded.Assets) != 3 {
 		t.Fatalf("unexpected assets len: %d", len(decoded.Assets))
 	}
 }

--- a/epub.go
+++ b/epub.go
@@ -3,6 +3,7 @@
 package epub
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/xml"
@@ -227,7 +228,9 @@ func (d *Document) AddAsset(mimeType string, r io.ReaderAt, size int64) (string,
 // AddPageWithAsset registers an asset and appends its page in one call.
 //
 // mime type and viewport width/height are derived from r.
-// If page creation fails after asset registration, the asset is rolled back.
+// The spine is linked to a generated XHTML wrapper to keep fixed-layout rendering
+// behavior consistent across readers (including Apple Books).
+// If page creation fails after asset registration, created assets are rolled back.
 func (d *Document) AddPageWithAsset(r io.ReaderAt, size int64, spread string) (*Page, *Asset, error) {
 	mimeType, width, height, err := detectAssetMeta(r, size)
 	if err != nil {
@@ -239,15 +242,86 @@ func (d *Document) AddPageWithAsset(r io.ReaderAt, size int64, spread string) (*
 		return nil, nil, err
 	}
 
-	page, err := d.AddPage(width, height, spread)
+	xhtmlHref, xhtmlAsset, err := d.addXHTMLPageAsset(assetHref, asset.ID, width, height)
 	if err != nil {
 		delete(d.Assets, assetHref)
 		return nil, nil, err
 	}
-	page.AssetID = asset.ID
-	page.Href = assetHref
+
+	page, err := d.AddPage(width, height, spread)
+	if err != nil {
+		delete(d.Assets, xhtmlHref)
+		delete(d.Assets, assetHref)
+		return nil, nil, err
+	}
+	page.AssetID = xhtmlAsset.ID
+	page.Href = xhtmlHref
 
 	return page, asset, nil
+}
+
+func (d *Document) addXHTMLPageAsset(imageHref, imageID string, width, height int) (string, *Asset, error) {
+	if d == nil {
+		return "", nil, ErrNilDocument
+	}
+	xhtmlID := "xhtml-" + imageID
+	xhtmlHref := path.Join("item/xhtml", imageID+".xhtml")
+	if d.Assets == nil {
+		d.Assets = make(map[string]*Asset)
+	}
+	if _, exists := d.Assets[xhtmlHref]; exists {
+		return "", nil, ErrDuplicateAssetPath
+	}
+	for _, a := range d.Assets {
+		if a != nil && a.ID == xhtmlID {
+			return "", nil, ErrDuplicateAssetID
+		}
+	}
+
+	imgSrc := path.Clean(path.Join("..", path.Base(path.Dir(imageHref)), path.Base(imageHref)))
+	body, err := buildXHTMLPageWrapper(width, height, imgSrc)
+	if err != nil {
+		return "", nil, err
+	}
+	asset := &Asset{
+		ID:       xhtmlID,
+		MimeType: "application/xhtml+xml",
+		Size:     uint64(len(body)),
+		Open: func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(body)), nil
+		},
+	}
+	if err := asset.CalculateHash(); err != nil {
+		return "", nil, err
+	}
+
+	d.Assets[xhtmlHref] = asset
+	return xhtmlHref, asset, nil
+}
+
+func buildXHTMLPageWrapper(width, height int, imgSrc string) ([]byte, error) {
+	doc := xhtmlDocument{
+		XMLNS:     "http://www.w3.org/1999/xhtml",
+		XMLNSEpub: "http://www.idpf.org/2007/ops",
+		Head: xhtmlHead{
+			Title: "Page",
+			Meta: xhtmlMeta{
+				Name:    "viewport",
+				Content: fmt.Sprintf("width=%d, height=%d", width, height),
+			},
+			Style: "html, body { margin: 0; padding: 0; width: 100%; height: 100%; overflow: hidden; }\n" +
+				"img { display: block; width: 100%; height: 100%; object-fit: contain; }",
+		},
+		Body: xhtmlBody{
+			Img: xhtmlImg{Src: imgSrc, Alt: ""},
+		},
+	}
+
+	b, err := xml.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append([]byte(xml.Header), b...), nil
 }
 
 func detectAssetMeta(r io.ReaderAt, size int64) (mimeType string, width int, height int, err error) {
@@ -277,48 +351,6 @@ func detectAssetMeta(r io.ReaderAt, size int64) (mimeType string, width int, hei
 		return "", 0, 0, err
 	}
 	return mimeType, cfg.Width, cfg.Height, nil
-}
-
-func readerAtSize(r io.ReaderAt) (int64, error) {
-	if s, ok := r.(interface{ Size() int64 }); ok {
-		return s.Size(), nil
-	}
-	if l, ok := r.(interface{ Len() int }); ok {
-		return int64(l.Len()), nil
-	}
-
-	one := make([]byte, 1)
-	var hi int64 = 1
-	for {
-		_, err := r.ReadAt(one, hi-1)
-		if err == nil {
-			if hi > (1 << 62) {
-				return 0, ErrCannotInferAssetSize
-			}
-			hi *= 2
-			continue
-		}
-		if errors.Is(err, io.EOF) {
-			break
-		}
-		return 0, err
-	}
-
-	lo := hi / 2
-	for lo+1 < hi {
-		mid := lo + (hi-lo)/2
-		_, err := r.ReadAt(one, mid-1)
-		if err == nil {
-			lo = mid
-			continue
-		}
-		if errors.Is(err, io.EOF) {
-			hi = mid
-			continue
-		}
-		return 0, err
-	}
-	return lo, nil
 }
 
 func (d *Document) nextAssetID() string {

--- a/epub_example_test.go
+++ b/epub_example_test.go
@@ -42,10 +42,14 @@ func ExampleDocument_AddPageWithAsset() {
 	}
 
 	fmt.Println(page.Order)
-	fmt.Println(page.AssetID == asset.ID)
+	fmt.Println(strings.HasPrefix(page.AssetID, "xhtml-"))
+	fmt.Println(page.Href)
+	fmt.Println(asset.MimeType)
 	fmt.Println(len(doc.Pages), len(doc.Assets))
 	// Output:
 	// 0
 	// true
-	// 1 1
+	// item/xhtml/p-001.xhtml
+	// image/png
+	// 1 2
 }

--- a/epub_test.go
+++ b/epub_test.go
@@ -47,7 +47,7 @@ func TestAddPageAutoDerivation(t *testing.T) {
 	}
 }
 
-func TestAddPageWithAssetSharesID(t *testing.T) {
+func TestAddPageWithAssetGeneratesXHTMLWrapper(t *testing.T) {
 	doc := &Document{}
 	pngBytes, err := base64.StdEncoding.DecodeString("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7Zk7kAAAAASUVORK5CYII=")
 	if err != nil {
@@ -59,10 +59,10 @@ func TestAddPageWithAssetSharesID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AddPageWithAsset returned error: %v", err)
 	}
-	if page.AssetID != asset.ID {
-		t.Fatalf("page asset id (%s) and asset id (%s) must match", page.AssetID, asset.ID)
+	if page.AssetID == asset.ID {
+		t.Fatalf("page asset id (%s) must point to wrapper, not image (%s)", page.AssetID, asset.ID)
 	}
-	if page.Href != "item/image/p-001.png" {
+	if page.Href != "item/xhtml/p-001.xhtml" {
 		t.Fatalf("unexpected page href: %s", page.Href)
 	}
 	if page.Spread != "left" {
@@ -70,6 +70,33 @@ func TestAddPageWithAssetSharesID(t *testing.T) {
 	}
 	if page.Width != 1 || page.Height != 1 {
 		t.Fatalf("unexpected viewport: %dx%d", page.Width, page.Height)
+	}
+	if len(doc.Assets) != 2 {
+		t.Fatalf("unexpected assets len: %d", len(doc.Assets))
+	}
+
+	wrapper := doc.Assets[page.Href]
+	if wrapper == nil {
+		t.Fatalf("wrapper asset not found: %s", page.Href)
+	}
+	if wrapper.MimeType != "application/xhtml+xml" {
+		t.Fatalf("unexpected wrapper mime type: %s", wrapper.MimeType)
+	}
+	rc, err := wrapper.Open()
+	if err != nil {
+		t.Fatalf("open wrapper failed: %v", err)
+	}
+	defer rc.Close()
+	body, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("read wrapper failed: %v", err)
+	}
+	xhtml := string(body)
+	if !strings.Contains(xhtml, `name="viewport" content="width=1, height=1"`) {
+		t.Fatalf("viewport meta is missing: %s", xhtml)
+	}
+	if !strings.Contains(xhtml, `img src="../image/p-001.png"`) {
+		t.Fatalf("image ref is missing: %s", xhtml)
 	}
 }
 
@@ -95,7 +122,7 @@ func TestDocumentExtractReferencedImagesFromSpineDirectImage(t *testing.T) {
 	if refs[0].Asset != asset {
 		t.Fatal("expected asset pointer to be preserved")
 	}
-	if refs[0].Href != page.Href {
+	if refs[0].Href != "item/image/p-001.png" {
 		t.Fatalf("unexpected href: %s", refs[0].Href)
 	}
 }
@@ -126,8 +153,11 @@ func TestDocumentGetAssetByPage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetAssetByPage returned error: %v", err)
 	}
-	if resolved != asset {
-		t.Fatal("resolved asset pointer should match returned asset")
+	if resolved == asset {
+		t.Fatal("resolved page asset should be wrapper, not returned image asset")
+	}
+	if resolved == nil || resolved.MimeType != "application/xhtml+xml" {
+		t.Fatalf("unexpected resolved page asset: %#v", resolved)
 	}
 }
 

--- a/xml_types.go
+++ b/xml_types.go
@@ -66,3 +66,33 @@ type spineItem struct {
 	IDRef      string `xml:"idref,attr"`
 	Properties string `xml:"properties,attr"`
 }
+
+type xhtmlMeta struct {
+	XMLName xml.Name `xml:"meta"`
+	Name    string   `xml:"name,attr"`
+	Content string   `xml:"content,attr"`
+}
+
+type xhtmlImg struct {
+	XMLName xml.Name `xml:"img"`
+	Src     string   `xml:"src,attr"`
+	Alt     string   `xml:"alt,attr"`
+}
+
+type xhtmlHead struct {
+	Title string    `xml:"title"`
+	Meta  xhtmlMeta `xml:"meta"`
+	Style string    `xml:"style"`
+}
+
+type xhtmlBody struct {
+	Img xhtmlImg `xml:"img"`
+}
+
+type xhtmlDocument struct {
+	XMLName   xml.Name  `xml:"html"`
+	XMLNS     string    `xml:"xmlns,attr"`
+	XMLNSEpub string    `xml:"xmlns:epub,attr"`
+	Head      xhtmlHead `xml:"head"`
+	Body      xhtmlBody `xml:"body"`
+}


### PR DESCRIPTION
## Summary
Fix rendering issues in strict fixed-layout readers by ensuring spine items generated by AddPageWithAsset are XHTML documents with viewport metadata.

## Changes
- generate an XHTML wrapper asset for each image page and point page.AssetID/page.Href to the wrapper
- keep AddPageWithAsset return value for the original image asset
- build wrapper XHTML using encoding/xml struct marshaling instead of raw XML templates
- centralize XHTML XML types in xml_types.go with existing XML DTOs
- update tests and examples to validate wrapper semantics and image reference extraction behavior

## Breaking Change
This change is intentionally marked as breaking:
- page.AssetID no longer matches the returned image asset ID
- page.Href now points to item/xhtml/... instead of item/image/...
- document asset count increases because each page now includes an XHTML wrapper

## Validation
- go test ./... passes
- CLI build-images output is valid in flexible mode and resolves page image references correctly

Closes #24