### PR TITLE
feat: add cover image support

### DIFF
--- a/cmd/epub/main.go
+++ b/cmd/epub/main.go
@@ -228,6 +228,7 @@ func runBuildFromImages(args []string) error {
 	layout := fs.String("layout", "pre-paginated", "pre-paginated|reflowable")
 	spread := fs.String("spread", "right", "left|right|center|none")
 	globPattern := fs.String("glob", "", "glob pattern for images (e.g. ./images/*.jpg)")
+	cover := fs.String("cover", "", "path to cover image (added as first page with cover semantics)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -281,6 +282,18 @@ func runBuildFromImages(args []string) error {
 			_ = f.Close()
 		}
 	}()
+
+	// Add cover image first if specified.
+	if cp := strings.TrimSpace(*cover); cp != "" {
+		cf, csize, err := openReaderAt(cp)
+		if err != nil {
+			return err
+		}
+		openFiles = append(openFiles, cf)
+		if _, _, err := doc.SetCover(cf, csize); err != nil {
+			return err
+		}
+	}
 
 	for _, p := range imagePaths {
 		f, size, err := openReaderAt(p)

--- a/decode.go
+++ b/decode.go
@@ -117,6 +117,7 @@ func Decode(r io.ReaderAt, size int64, opts ...DecodeOption) (*Document, error) 
 			Identifier:        identifier,
 			IdentifierID:      identifierID,
 			Creators:          parseCreators(pkg.Metadata.Creators, fileAsByRefines),
+			CoverAssetID:      parseCoverAssetID(normalizedManifest, pkg.Metadata.Meta),
 			EBPAJGuideVersion: parseMetaValueByProperty(pkg.Metadata.Meta, "ebpaj:guide-version"),
 			KADOKAWAVersion:   parseMetaValueByProperty(pkg.Metadata.Meta, "kadokawa:version"),
 		},
@@ -164,6 +165,17 @@ func Decode(r io.ReaderAt, size int64, opts ...DecodeOption) (*Document, error) 
 			page.Height = height
 		}
 		doc.Pages = append(doc.Pages, page)
+	}
+
+	// Mark cover page based on CoverAssetID.
+	if coverID := doc.Metadata.CoverAssetID; coverID != "" {
+		wrapperID := "xhtml-" + coverID
+		for _, pg := range doc.Pages {
+			if pg.AssetID == wrapperID || pg.AssetID == coverID {
+				pg.Type = PageTypeCover
+				break
+			}
+		}
 	}
 
 	reservedPaths := map[string]struct{}{
@@ -496,4 +508,22 @@ func validateResourceLimits(zr *zip.Reader, cfg decodeConfig) error {
 	}
 
 	return nil
+}
+
+func parseCoverAssetID(manifest []manifestItem, meta []metadataMeta) string {
+	for _, item := range manifest {
+		for _, prop := range strings.Fields(item.Properties) {
+			if strings.EqualFold(prop, "cover-image") {
+				return item.ID
+			}
+		}
+	}
+	for _, m := range meta {
+		if strings.EqualFold(strings.TrimSpace(m.Name), "cover") {
+			if v := strings.TrimSpace(m.Content); v != "" {
+				return v
+			}
+		}
+	}
+	return ""
 }

--- a/encode.go
+++ b/encode.go
@@ -94,6 +94,8 @@ func writePackageAndAssets(zw *zip.Writer, doc *Document, cfg encodeConfig) erro
 	identifierID := normalizeIdentifierID(metadata.IdentifierID)
 	navHref := "nav.xhtml"
 
+	coverAssetID := resolveCoverAssetID(doc, assetPaths)
+
 	manifestItems := make([]string, 0, len(assetPaths))
 	opfDir := "item"
 	for _, p := range assetPaths {
@@ -102,11 +104,27 @@ func writePackageAndAssets(zw *zip.Writer, doc *Document, cfg encodeConfig) erro
 		if rel, err := filepath.Rel(opfDir, p); err == nil {
 			href = filepath.ToSlash(rel)
 		}
-		manifestItems = append(manifestItems, fmt.Sprintf(`<item id=%q href=%q media-type=%q/>`, xmlEscape(a.ID), xmlEscape(href), xmlEscape(a.MimeType)))
+		item := manifestItem{ID: a.ID, Href: href, MediaType: a.MimeType}
+		if coverAssetID != "" && a.ID == coverAssetID {
+			item.Properties = "cover-image"
+		}
+		b, err := xml.Marshal(item)
+		if err != nil {
+			return err
+		}
+		manifestItems = append(manifestItems, string(b))
 	}
-	manifestItems = append(manifestItems, fmt.Sprintf(`<item id="nav" href=%q media-type="application/xhtml+xml" properties="nav"/>`, xmlEscape(navHref)))
+	navItemBytes, err := xml.Marshal(manifestItem{ID: "nav", Href: navHref, MediaType: "application/xhtml+xml", Properties: "nav"})
+	if err != nil {
+		return err
+	}
+	manifestItems = append(manifestItems, string(navItemBytes))
 	if cfg.generateLegacyTOC {
-		manifestItems = append(manifestItems, `<item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>`)
+		ncxItemBytes, err := xml.Marshal(manifestItem{ID: "ncx", Href: "toc.ncx", MediaType: "application/x-dtbncx+xml"})
+		if err != nil {
+			return err
+		}
+		manifestItems = append(manifestItems, string(ncxItemBytes))
 	}
 
 	spineItems := make([]string, 0, len(doc.Pages))
@@ -148,6 +166,14 @@ func writePackageAndAssets(zw *zip.Writer, doc *Document, cfg encodeConfig) erro
 		}
 	}
 
+	if coverAssetID != "" {
+		coverMetaBytes, err := xml.Marshal(metadataMeta{Name: "cover", Content: coverAssetID})
+		if err != nil {
+			return err
+		}
+		metadataEntries = append(metadataEntries, string(coverMetaBytes))
+	}
+
 	metadataEntries = append(metadataEntries,
 		fmt.Sprintf(`<meta property="rendition:layout">%s</meta>`, xmlEscape(rLayout)),
 		fmt.Sprintf(`<meta property="dcterms:modified">%s</meta>`, xmlEscape(formatW3CTime(time.Now()))),
@@ -176,7 +202,7 @@ func writePackageAndAssets(zw *zip.Writer, doc *Document, cfg encodeConfig) erro
 		return err
 	}
 
-	nav, err := buildNavigationDocument(doc, navHref)
+	nav, err := buildNavigationDocument(doc, navHref, coverAssetID)
 	if err != nil {
 		return err
 	}
@@ -270,8 +296,53 @@ func formatW3CTime(t time.Time) string {
 	return t.UTC().Format("2006-01-02T15:04:05Z")
 }
 
-func buildNavigationDocument(doc *Document, navHref string) (string, error) {
-	tocItems := make([]string, 0, len(doc.Pages))
+func resolveCoverAssetID(doc *Document, sortedPaths []string) string {
+	m := doc.effectiveMetadata()
+	if id := strings.TrimSpace(m.CoverAssetID); id != "" {
+		for _, a := range doc.Assets {
+			if a != nil && a.ID == id {
+				return id
+			}
+		}
+		return ""
+	}
+	for _, p := range sortedPaths {
+		a := doc.Assets[p]
+		if a != nil && strings.HasPrefix(a.MimeType, "image/") {
+			return a.ID
+		}
+	}
+	return ""
+}
+
+func resolveCoverPageHref(doc *Document, coverAssetID string) string {
+	if coverAssetID == "" {
+		return ""
+	}
+	// Prefer page explicitly marked as cover.
+	for _, pg := range doc.Pages {
+		if pg.Type == PageTypeCover {
+			href := strings.TrimSpace(pg.Href)
+			if href != "" {
+				return strings.TrimPrefix(href, "item/")
+			}
+		}
+	}
+	// Fallback: find XHTML wrapper matching coverAssetID.
+	wrapperID := "xhtml-" + coverAssetID
+	for _, pg := range doc.Pages {
+		if pg.AssetID == wrapperID || pg.AssetID == coverAssetID {
+			href := strings.TrimSpace(pg.Href)
+			if href != "" {
+				return strings.TrimPrefix(href, "item/")
+			}
+		}
+	}
+	return ""
+}
+
+func buildNavigationDocument(doc *Document, navHref string, coverAssetID string) (string, error) {
+	tocItems := make([]navListItem, 0, len(doc.Pages))
 	for i, pg := range doc.Pages {
 		href := strings.TrimSpace(pg.Href)
 		if href == "" {
@@ -284,49 +355,69 @@ func buildNavigationDocument(doc *Document, navHref string) (string, error) {
 				}
 			}
 		}
-		href = xmlEscape(strings.TrimPrefix(cleanOPFRef("item", href), "item/"))
+		href = strings.TrimPrefix(href, "item/")
 		if href == "" {
 			href = "#"
 		}
-		tocItems = append(tocItems, fmt.Sprintf(`<li><a href=%q>Page %d</a></li>`, href, i+1))
+		tocItems = append(tocItems, navListItem{
+			Anchor: navLandmarkAnchor{Href: href, Text: fmt.Sprintf("Page %d", i+1)},
+		})
 	}
 	if len(tocItems) == 0 {
-		tocItems = append(tocItems, `<li><a href="#">Start</a></li>`)
+		tocItems = []navListItem{{Anchor: navLandmarkAnchor{Href: "#", Text: "Start"}}}
+	}
+
+	coverHref := resolveCoverPageHref(doc, coverAssetID)
+	if coverHref == "" && len(doc.Pages) > 0 {
+		first := strings.TrimSpace(doc.Pages[0].Href)
+		if first != "" {
+			coverHref = strings.TrimPrefix(first, "item/")
+		}
+	}
+	if coverHref == "" {
+		coverHref = "#"
 	}
 
 	bodyHref := "#"
 	if len(doc.Pages) > 0 {
 		first := strings.TrimSpace(doc.Pages[0].Href)
 		if first != "" {
-			bodyHref = xmlEscape(strings.TrimPrefix(cleanOPFRef("item", first), "item/"))
+			bodyHref = strings.TrimPrefix(first, "item/")
 		}
 	}
 	if bodyHref == "" {
 		bodyHref = "#"
 	}
 
-	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
-  <head>
-    <title>Navigation</title>
-  </head>
-  <body>
-    <nav epub:type="toc" id="toc">
-      <h1>Navigation</h1>
-      <ol>
-        %s
-      </ol>
-    </nav>
-    <nav epub:type="landmarks" id="landmarks">
-      <h2>Landmarks</h2>
-      <ol>
-        <li><a epub:type="cover" href=%q>Cover</a></li>
-        <li><a epub:type="toc" href=%q>Navigation</a></li>
-        <li><a epub:type="bodymatter" href=%q>Body</a></li>
-      </ol>
-    </nav>
-  </body>
-</html>`, strings.Join(tocItems, "\n        "), bodyHref, xmlEscape(navHref), bodyHref), nil
+	navDoc := navDocument{
+		Head: navDocHead{Title: "Navigation"},
+		Sections: []navSection{
+			{
+				EpubType:    "toc",
+				ID:          "toc",
+				HeadingTag:  "h1",
+				HeadingText: "Navigation",
+				Items:       tocItems,
+			},
+			{
+				EpubType:    "landmarks",
+				ID:          "landmarks",
+				HeadingTag:  "h2",
+				HeadingText: "Landmarks",
+				Items: []navListItem{
+					{Anchor: navLandmarkAnchor{EpubType: "cover", Href: coverHref, Text: "Cover"}},
+					{Anchor: navLandmarkAnchor{EpubType: "toc", Href: navHref, Text: "Navigation"}},
+					{Anchor: navLandmarkAnchor{EpubType: "bodymatter", Href: bodyHref, Text: "Body"}},
+				},
+			},
+		},
+	}
+
+	b, err := xml.MarshalIndent(navDoc, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return xml.Header + string(b), nil
 }
 
 func buildLegacyNCX(doc *Document, identifier string) string {

--- a/encode_test.go
+++ b/encode_test.go
@@ -118,7 +118,7 @@ func TestEncode_GeneratesNavigationDocument(t *testing.T) {
 	}
 
 	opfContent := readZipEntry(t, out.Bytes(), "item/standard.opf")
-	if !strings.Contains(opfContent, `<item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>`) {
+	if !strings.Contains(opfContent, `<item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav">`) {
 		t.Fatalf("opf nav manifest item missing: %s", opfContent)
 	}
 }
@@ -143,10 +143,10 @@ func TestEncode_WithLegacyTOC_GeneratesNCXWithMatchingUID(t *testing.T) {
 	if !strings.Contains(opfContent, `<dc:identifier id="pub-id">E-2026-0002</dc:identifier>`) {
 		t.Fatalf("opf identifier missing: %s", opfContent)
 	}
-	if !strings.Contains(opfContent, `<item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>`) {
+	if !strings.Contains(opfContent, `<item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav">`) {
 		t.Fatalf("opf nav.xhtml item missing: %s", opfContent)
 	}
-	if !strings.Contains(opfContent, `<item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>`) {
+	if !strings.Contains(opfContent, `<item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml">`) {
 		t.Fatalf("opf ncx item missing: %s", opfContent)
 	}
 	if !strings.Contains(opfContent, `<spine page-progression-direction="ltr" toc="ncx">`) {
@@ -246,5 +246,190 @@ func testPNGBytes() []byte {
 		0x00, 0x03, 0x01, 0x01, 0x00, 0xc9, 0xfe, 0x92,
 		0xef, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e,
 		0x44, 0xae, 0x42, 0x60, 0x82,
+	}
+}
+
+func TestEncode_CoverImageAutoFallback(t *testing.T) {
+	doc := &Document{
+		Metadata:  Metadata{Title: "Cover Auto"},
+		Direction: "rtl",
+		Layout:    LayoutPrePaginated,
+	}
+	png := testPNGBytes()
+	_, asset, err := doc.AddPageWithAsset(bytes.NewReader(png), int64(len(png)), "right")
+	if err != nil {
+		t.Fatalf("AddPageWithAsset failed: %v", err)
+	}
+
+	var out bytes.Buffer
+	if err := Encode(&out, doc); err != nil {
+		t.Fatalf("Encode failed: %v", err)
+	}
+
+	opfContent := readZipEntry(t, out.Bytes(), "item/standard.opf")
+	expected := `<item id="` + asset.ID + `" href="image/` + asset.ID + `.png" media-type="image/png" properties="cover-image"></item>`
+	if !strings.Contains(opfContent, expected) {
+		t.Fatalf("cover-image property missing in manifest:\n%s", opfContent)
+	}
+	if !strings.Contains(opfContent, `<meta name="cover" content="`+asset.ID+`"></meta>`) {
+		t.Fatalf("cover meta missing in metadata:\n%s", opfContent)
+	}
+}
+
+func TestEncode_CoverImageExplicit(t *testing.T) {
+	doc := &Document{
+		Metadata:  Metadata{Title: "Cover Explicit"},
+		Direction: "rtl",
+		Layout:    LayoutPrePaginated,
+	}
+	png := testPNGBytes()
+	// Add two pages; explicitly set the second as cover.
+	_, _, err := doc.AddPageWithAsset(bytes.NewReader(png), int64(len(png)), "right")
+	if err != nil {
+		t.Fatalf("AddPageWithAsset 1 failed: %v", err)
+	}
+	_, asset2, err := doc.AddPageWithAsset(bytes.NewReader(png), int64(len(png)), "left")
+	if err != nil {
+		t.Fatalf("AddPageWithAsset 2 failed: %v", err)
+	}
+	doc.Metadata.CoverAssetID = asset2.ID
+
+	var out bytes.Buffer
+	if err := Encode(&out, doc); err != nil {
+		t.Fatalf("Encode failed: %v", err)
+	}
+
+	opfContent := readZipEntry(t, out.Bytes(), "item/standard.opf")
+	expected := `<item id="` + asset2.ID + `" href="image/` + asset2.ID + `.png" media-type="image/png" properties="cover-image"></item>`
+	if !strings.Contains(opfContent, expected) {
+		t.Fatalf("cover-image property missing for explicit cover asset:\n%s", opfContent)
+	}
+	if !strings.Contains(opfContent, `<meta name="cover" content="`+asset2.ID+`"></meta>`) {
+		t.Fatalf("cover meta missing for explicit cover asset:\n%s", opfContent)
+	}
+
+	// Verify the first asset does NOT have cover-image.
+	if strings.Contains(opfContent, `<item id="p-001" href="image/p-001.png" media-type="image/png" properties="cover-image"`) {
+		t.Fatalf("first asset should not have cover-image property:\n%s", opfContent)
+	}
+}
+
+func TestEncode_CoverImageNavLandmark(t *testing.T) {
+	doc := &Document{
+		Metadata:  Metadata{Title: "Cover Nav"},
+		Direction: "rtl",
+		Layout:    LayoutPrePaginated,
+	}
+	png := testPNGBytes()
+	_, _, err := doc.AddPageWithAsset(bytes.NewReader(png), int64(len(png)), "right")
+	if err != nil {
+		t.Fatalf("AddPageWithAsset failed: %v", err)
+	}
+
+	var out bytes.Buffer
+	if err := Encode(&out, doc); err != nil {
+		t.Fatalf("Encode failed: %v", err)
+	}
+
+	navContent := readZipEntry(t, out.Bytes(), "item/nav.xhtml")
+	// The cover landmark and bodymatter landmark should both point to the page wrapper.
+	if !strings.Contains(navContent, `epub:type="cover"`) {
+		t.Fatalf("cover landmark missing:\n%s", navContent)
+	}
+	// Cover and bodymatter point to the same single page.
+	coverRe := regexp.MustCompile(`epub:type="cover" href="([^"]+)"`)
+	bodyRe := regexp.MustCompile(`epub:type="bodymatter" href="([^"]+)"`)
+	coverMatch := coverRe.FindStringSubmatch(navContent)
+	bodyMatch := bodyRe.FindStringSubmatch(navContent)
+	if len(coverMatch) < 2 || len(bodyMatch) < 2 {
+		t.Fatalf("could not find cover/bodymatter hrefs:\n%s", navContent)
+	}
+	if coverMatch[1] != bodyMatch[1] {
+		t.Fatalf("cover and bodymatter should point to same page: cover=%q body=%q", coverMatch[1], bodyMatch[1])
+	}
+}
+
+func TestEncodeDecode_CoverImageRoundTrip(t *testing.T) {
+	doc := &Document{
+		Metadata:  Metadata{Title: "Cover RoundTrip"},
+		Direction: "ltr",
+		Layout:    LayoutPrePaginated,
+	}
+	png := testPNGBytes()
+	_, asset, err := doc.AddPageWithAsset(bytes.NewReader(png), int64(len(png)), "right")
+	if err != nil {
+		t.Fatalf("AddPageWithAsset failed: %v", err)
+	}
+	doc.Metadata.CoverAssetID = asset.ID
+
+	var out bytes.Buffer
+	if err := Encode(&out, doc); err != nil {
+		t.Fatalf("Encode failed: %v", err)
+	}
+
+	decoded, err := Decode(bytes.NewReader(out.Bytes()), int64(out.Len()))
+	if err != nil {
+		t.Fatalf("Decode failed: %v", err)
+	}
+	if decoded.Metadata.CoverAssetID != asset.ID {
+		t.Fatalf("CoverAssetID mismatch: got %q, want %q", decoded.Metadata.CoverAssetID, asset.ID)
+	}
+}
+
+func TestSetCover(t *testing.T) {
+	doc := &Document{
+		Metadata:  Metadata{Title: "SetCover Test"},
+		Direction: "rtl",
+		Layout:    LayoutPrePaginated,
+	}
+	png := testPNGBytes()
+	// Add a body page first.
+	_, _, err := doc.AddPageWithAsset(bytes.NewReader(png), int64(len(png)), "right")
+	if err != nil {
+		t.Fatalf("AddPageWithAsset failed: %v", err)
+	}
+
+	// Add cover via SetCover; it should be inserted at front.
+	coverPage, coverAsset, err := doc.SetCover(bytes.NewReader(png), int64(len(png)))
+	if err != nil {
+		t.Fatalf("SetCover failed: %v", err)
+	}
+	if coverPage.Type != PageTypeCover {
+		t.Fatalf("cover page Type = %q, want %q", coverPage.Type, PageTypeCover)
+	}
+	if doc.Metadata.CoverAssetID != coverAsset.ID {
+		t.Fatalf("CoverAssetID = %q, want %q", doc.Metadata.CoverAssetID, coverAsset.ID)
+	}
+	if doc.Pages[0] != coverPage {
+		t.Fatalf("cover page should be first in Pages")
+	}
+	if doc.Pages[0].Order != 0 {
+		t.Fatalf("cover page Order = %d, want 0", doc.Pages[0].Order)
+	}
+	if doc.Pages[1].Order != 1 {
+		t.Fatalf("body page Order = %d, want 1", doc.Pages[1].Order)
+	}
+
+	// Encode and decode; Page.Type must survive via cover-image detection.
+	var out bytes.Buffer
+	if err := Encode(&out, doc); err != nil {
+		t.Fatalf("Encode failed: %v", err)
+	}
+	decoded, err := Decode(bytes.NewReader(out.Bytes()), int64(out.Len()))
+	if err != nil {
+		t.Fatalf("Decode failed: %v", err)
+	}
+	if decoded.Metadata.CoverAssetID != coverAsset.ID {
+		t.Fatalf("decoded CoverAssetID = %q, want %q", decoded.Metadata.CoverAssetID, coverAsset.ID)
+	}
+	foundCover := false
+	for _, pg := range decoded.Pages {
+		if pg.Type == PageTypeCover {
+			foundCover = true
+			break
+		}
+	}
+	if !foundCover {
+		t.Fatal("no page with PageTypeCover found after decode")
 	}
 }

--- a/epub.go
+++ b/epub.go
@@ -45,6 +45,7 @@ type Metadata struct {
 	Identifier        string
 	IdentifierID      string
 	Creators          []Creator
+	CoverAssetID      string
 	EBPAJGuideVersion string
 	KADOKAWAVersion   string
 }
@@ -260,6 +261,32 @@ func (d *Document) AddPageWithAsset(r io.ReaderAt, size int64, spread string) (*
 	return page, asset, nil
 }
 
+// SetCover adds a cover image asset and its wrapper page, marking it as the cover
+// in both the metadata (properties="cover-image") and the spine (PageTypeCover).
+// The cover page is inserted at the beginning of Pages (Order 0).
+func (d *Document) SetCover(r io.ReaderAt, size int64) (*Page, *Asset, error) {
+	page, asset, err := d.AddPageWithAsset(r, size, "center")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	d.Metadata.CoverAssetID = asset.ID
+	page.Type = PageTypeCover
+
+	// Move cover page to front of Pages.
+	if len(d.Pages) > 1 {
+		last := len(d.Pages) - 1
+		cover := d.Pages[last]
+		copy(d.Pages[1:], d.Pages[:last])
+		d.Pages[0] = cover
+		for i, pg := range d.Pages {
+			pg.Order = i
+		}
+	}
+
+	return page, asset, nil
+}
+
 func (d *Document) addXHTMLPageAsset(imageHref, imageID string, width, height int) (string, *Asset, error) {
 	if d == nil {
 		return "", nil, ErrNilDocument
@@ -396,6 +423,18 @@ func fileExtFromMimeType(mimeType string) (string, bool) {
 	}
 }
 
+// PageType represents semantic role of a page in the reading order.
+type PageType string
+
+const (
+	// PageTypeStandard is a regular content page (default).
+	PageTypeStandard PageType = ""
+	// PageTypeCover marks the page as the cover page.
+	PageTypeCover PageType = "cover"
+	// PageTypeTOC marks the page as a table of contents page.
+	PageTypeTOC PageType = "toc"
+)
+
 // Page is a single reading-order entry in spine.
 type Page struct {
 	Order   int
@@ -403,7 +442,8 @@ type Page struct {
 	Href    string
 	Width   int
 	Height  int
-	Spread  string // "left", "right", "center", "none".
+	Spread  string   // "left", "right", "center", "none".
+	Type    PageType // Semantic role of the page.
 }
 
 // Asset points to a binary object referenced from EPUB manifest.

--- a/testdata_test.go
+++ b/testdata_test.go
@@ -3,6 +3,7 @@
 package epub_test
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -132,6 +133,69 @@ func TestTestdata_DPFJTemplates(t *testing.T) {
 			}
 			if doc.Direction != "rtl" {
 				t.Errorf("Direction = %q, want rtl", doc.Direction)
+			}
+		})
+	}
+}
+
+func TestTestdata_CoverImageRoundTrip(t *testing.T) {
+	paths := testdataEPUBs(t)
+	if len(paths) == 0 {
+		t.Skip("no epub files in testdata/ (see testdata/README.md)")
+	}
+	for _, p := range paths {
+		base := filepath.Base(p)
+		// Skip sizecheck EPUBs; they are intentionally non-compliant.
+		if strings.Contains(base, "sizecheck") {
+			continue
+		}
+		t.Run(base, func(t *testing.T) {
+			f, err := os.Open(p)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer f.Close()
+
+			st, err := f.Stat()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			doc, err := epub.Decode(f, st.Size())
+			if err != nil {
+				t.Fatalf("Decode failed: %v", err)
+			}
+
+			coverID := doc.Metadata.CoverAssetID
+			if coverID == "" {
+				t.Log("no cover-image detected; skipping round-trip check")
+				return
+			}
+
+			// Verify the cover asset actually exists.
+			found := false
+			for _, a := range doc.Assets {
+				if a != nil && a.ID == coverID {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("CoverAssetID %q not found in assets", coverID)
+			}
+
+			// Encode back and decode; CoverAssetID must survive.
+			var buf bytes.Buffer
+			if err := epub.Encode(&buf, doc); err != nil {
+				t.Fatalf("Encode failed: %v", err)
+			}
+
+			doc2, err := epub.Decode(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+			if err != nil {
+				t.Fatalf("re-Decode failed: %v", err)
+			}
+			if doc2.Metadata.CoverAssetID != coverID {
+				t.Errorf("CoverAssetID after round-trip = %q, want %q", doc2.Metadata.CoverAssetID, coverID)
 			}
 		})
 	}

--- a/xml_types.go
+++ b/xml_types.go
@@ -39,11 +39,12 @@ type dcElement struct {
 }
 
 type metadataMeta struct {
-	Property string `xml:"property,attr"`
-	Refines  string `xml:"refines,attr"`
-	Name     string `xml:"name,attr"`
-	Content  string `xml:"content,attr"`
-	Value    string `xml:",chardata"`
+	XMLName  xml.Name `xml:"meta"`
+	Property string   `xml:"property,attr,omitempty"`
+	Refines  string   `xml:"refines,attr,omitempty"`
+	Name     string   `xml:"name,attr,omitempty"`
+	Content  string   `xml:"content,attr,omitempty"`
+	Value    string   `xml:",chardata"`
 }
 
 type packageManifest struct {
@@ -51,10 +52,11 @@ type packageManifest struct {
 }
 
 type manifestItem struct {
-	ID         string `xml:"id,attr"`
-	Href       string `xml:"href,attr"`
-	MediaType  string `xml:"media-type,attr"`
-	Properties string `xml:"properties,attr"`
+	XMLName    xml.Name `xml:"item"`
+	ID         string   `xml:"id,attr"`
+	Href       string   `xml:"href,attr"`
+	MediaType  string   `xml:"media-type,attr"`
+	Properties string   `xml:"properties,attr,omitempty"`
 }
 
 type packageSpine struct {
@@ -95,4 +97,131 @@ type xhtmlDocument struct {
 	XMLNSEpub string    `xml:"xmlns:epub,attr"`
 	Head      xhtmlHead `xml:"head"`
 	Body      xhtmlBody `xml:"body"`
+}
+
+// navLandmarkAnchor represents an <a> element in the navigation landmarks.
+// It uses a custom MarshalXML to emit the epub:type attribute with a prefixed
+// name (not a namespace URI) so the output is compatible with the parent
+// <html xmlns:epub="…"> declaration.
+type navLandmarkAnchor struct {
+	EpubType string
+	Href     string
+	Text     string
+}
+
+func (a navLandmarkAnchor) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	start.Name = xml.Name{Local: "a"}
+	if a.EpubType != "" {
+		start.Attr = append(start.Attr, xml.Attr{
+			Name:  xml.Name{Local: "epub:type"},
+			Value: a.EpubType,
+		})
+	}
+	start.Attr = append(start.Attr, xml.Attr{
+		Name:  xml.Name{Local: "href"},
+		Value: a.Href,
+	})
+	if err := e.EncodeToken(start); err != nil {
+		return err
+	}
+	if err := e.EncodeToken(xml.CharData(a.Text)); err != nil {
+		return err
+	}
+	return e.EncodeToken(start.End())
+}
+
+// navDocument represents the full navigation XHTML document (nav.xhtml).
+type navDocument struct {
+	Head     navDocHead
+	Sections []navSection
+}
+
+func (d navDocument) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	start.Name = xml.Name{Local: "html"}
+	start.Attr = []xml.Attr{
+		{Name: xml.Name{Local: "xmlns"}, Value: "http://www.w3.org/1999/xhtml"},
+		{Name: xml.Name{Local: "xmlns:epub"}, Value: "http://www.idpf.org/2007/ops"},
+	}
+	if err := e.EncodeToken(start); err != nil {
+		return err
+	}
+	if err := e.EncodeElement(d.Head, xml.StartElement{Name: xml.Name{Local: "head"}}); err != nil {
+		return err
+	}
+	bodyStart := xml.StartElement{Name: xml.Name{Local: "body"}}
+	if err := e.EncodeToken(bodyStart); err != nil {
+		return err
+	}
+	for i := range d.Sections {
+		if err := e.EncodeElement(d.Sections[i], xml.StartElement{Name: xml.Name{Local: "nav"}}); err != nil {
+			return err
+		}
+	}
+	if err := e.EncodeToken(bodyStart.End()); err != nil {
+		return err
+	}
+	return e.EncodeToken(start.End())
+}
+
+type navDocHead struct {
+	Title string `xml:"title"`
+}
+
+// navSection represents a <nav> element with an epub:type attribute.
+type navSection struct {
+	EpubType    string
+	ID          string
+	HeadingTag  string // e.g. "h1", "h2"
+	HeadingText string
+	Items       []navListItem
+}
+
+func (s navSection) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	start.Name = xml.Name{Local: "nav"}
+	start.Attr = []xml.Attr{
+		{Name: xml.Name{Local: "epub:type"}, Value: s.EpubType},
+		{Name: xml.Name{Local: "id"}, Value: s.ID},
+	}
+	if err := e.EncodeToken(start); err != nil {
+		return err
+	}
+	hStart := xml.StartElement{Name: xml.Name{Local: s.HeadingTag}}
+	if err := e.EncodeToken(hStart); err != nil {
+		return err
+	}
+	if err := e.EncodeToken(xml.CharData(s.HeadingText)); err != nil {
+		return err
+	}
+	if err := e.EncodeToken(hStart.End()); err != nil {
+		return err
+	}
+	olStart := xml.StartElement{Name: xml.Name{Local: "ol"}}
+	if err := e.EncodeToken(olStart); err != nil {
+		return err
+	}
+	for i := range s.Items {
+		if err := e.EncodeElement(s.Items[i], xml.StartElement{Name: xml.Name{Local: "li"}}); err != nil {
+			return err
+		}
+	}
+	if err := e.EncodeToken(olStart.End()); err != nil {
+		return err
+	}
+	return e.EncodeToken(start.End())
+}
+
+// navListItem represents a <li> element wrapping an anchor.
+type navListItem struct {
+	Anchor navLandmarkAnchor
+}
+
+func (li navListItem) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	start.Name = xml.Name{Local: "li"}
+	if err := e.EncodeToken(start); err != nil {
+		return err
+	}
+	if err := e.EncodeElement(li.Anchor, xml.StartElement{Name: xml.Name{Local: "a"}}); err != nil {
+		return err
+	}
+	return e.EncodeToken(start.End())
 }


### PR DESCRIPTION
## Summary

Add cover image support per #27.

### Model changes (`epub.go`)
- `Metadata.CoverAssetID` — cover image asset ID for `properties="cover-image"`
- `PageType` type with `PageTypeCover`, `PageTypeTOC` constants
- `Page.Type` field for semantic page roles
- `SetCover(r, size)` helper — one-call cover setup: registers image + XHTML wrapper, sets metadata, marks `PageTypeCover`, inserts at front of `Pages`

### Encode (`encode.go`)
- Emit `properties="cover-image"` on manifest item via `xml.Marshal`
- Emit `<meta name="cover">` in metadata for EPUB 2 backward compat
- Emit `epub:type="cover"` landmark in nav.xhtml
- Build nav.xhtml entirely via `xml.MarshalIndent` with custom `MarshalXML` types
- Fix: double `item/` prefix in nav href resolution

### Decode (`decode.go`)
- Parse `cover-image` from manifest properties, fallback to `<meta name="cover">`
- Set `Page.Type = PageTypeCover` on the corresponding spine page

### XML types (`xml_types.go`)
- `navDocument`, `navSection`, `navListItem`, `navLandmarkAnchor` with custom `MarshalXML` for `epub:type` attribute handling

### CLI (`cmd/epub`)
- `build-images -cover <path>` flag to specify cover image

### Tests
- `TestEncode_CoverImageAutoFallback`
- `TestEncode_CoverImageExplicit`
- `TestEncode_CoverImageNavLandmark`
- `TestEncodeDecode_CoverImageRoundTrip`
- `TestSetCover`
- `TestTestdata_CoverImageRoundTrip`

Closes #27