### PR TITLE
feat: add optional preflight compliance warnings before Encode

### DIFF
--- a/compliance.go
+++ b/compliance.go
@@ -4,6 +4,7 @@ package epub
 
 import (
 	"archive/zip"
+	"bytes"
 	"fmt"
 	"image"
 	"io"
@@ -192,4 +193,108 @@ func validateJPEGSpecs(r io.Reader, href string) error {
 	}
 
 	return nil
+}
+
+// preflightEncode runs lightweight compliance checks against a Document before
+// encoding.  It returns non-fatal warning strings; it never returns errors.
+// Only strict profiles (LevelEBPAJ, LevelKADOKAWA) produce meaningful output.
+func preflightEncode(level ComplianceLevel, doc *Document) []string {
+	if level == LevelFlexible || doc == nil {
+		return nil
+	}
+
+	var warnings []string
+
+	for href, asset := range doc.Assets {
+		if asset == nil {
+			continue
+		}
+		mt := strings.ToLower(strings.TrimSpace(asset.MimeType))
+
+		// Directory layout check.
+		dir := path.Dir(href)
+		if dir == "." || (!strings.HasPrefix(href, "item/xhtml/") &&
+			!strings.HasPrefix(href, "item/image/") &&
+			!strings.HasPrefix(href, "item/style/") &&
+			dir != "item") {
+			warnings = append(warnings, fmt.Sprintf("asset %q does not follow the expected directory layout", href))
+		}
+
+		if strings.HasPrefix(mt, "image/") {
+			// Image naming.
+			switch level {
+			case LevelEBPAJ:
+				if !imageNamePatternEBPAJ.MatchString(href) {
+					warnings = append(warnings, fmt.Sprintf("image %q does not match EBPAJ naming pattern", href))
+				}
+			case LevelKADOKAWA:
+				if !imageNamePatternKADOKAWA.MatchString(href) {
+					warnings = append(warnings, fmt.Sprintf("image %q does not match KADOKAWA naming pattern", href))
+				}
+			}
+
+			// File size.
+			if asset.Size > uint64(maxImageFileSize) {
+				warnings = append(warnings, fmt.Sprintf("image %q file size %s exceeds %s limit",
+					href, formatBytes(int64(asset.Size)), formatBytes(maxImageFileSize)))
+			}
+
+			// Pixel count and progressive JPEG (requires opening asset).
+			if asset.Open != nil {
+				if w := preflightImageSpecs(href, asset); len(w) > 0 {
+					warnings = append(warnings, w...)
+				}
+			}
+		} else if strings.Contains(mt, "xhtml") {
+			if asset.Size > uint64(maxXHTMLFileSize) {
+				warnings = append(warnings, fmt.Sprintf("XHTML file %q size %s exceeds %s, may cause RS performance issues",
+					href, formatBytes(int64(asset.Size)), formatBytes(int64(maxXHTMLFileSize))))
+			}
+		}
+	}
+	return warnings
+}
+
+// preflightImageSpecs opens an image asset and checks pixel count and JPEG encoding.
+func preflightImageSpecs(href string, asset *Asset) []string {
+	rc, err := asset.Open()
+	if err != nil {
+		return nil
+	}
+	defer rc.Close()
+
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		return nil
+	}
+
+	var warnings []string
+
+	cfg, format, err := image.DecodeConfig(bytes.NewReader(data))
+	if err != nil {
+		return nil
+	}
+	pixelCount := int64(cfg.Width) * int64(cfg.Height)
+	if pixelCount > maxImagePixelCount {
+		warnings = append(warnings, fmt.Sprintf("image %q pixel count %d exceeds %d limit",
+			href, pixelCount, maxImagePixelCount))
+	}
+
+	if format == "jpeg" {
+		if isProgressiveJPEG(data) {
+			warnings = append(warnings, fmt.Sprintf("image %q is a progressive JPEG, which is not allowed", href))
+		}
+	}
+
+	return warnings
+}
+
+// isProgressiveJPEG detects progressive JPEG by looking for SOF2 marker (0xFFC2).
+func isProgressiveJPEG(data []byte) bool {
+	for i := 0; i < len(data)-1; i++ {
+		if data[i] == 0xFF && data[i+1] == 0xC2 {
+			return true
+		}
+	}
+	return false
 }

--- a/compliance_test.go
+++ b/compliance_test.go
@@ -4,7 +4,10 @@ package epub
 
 import (
 	"archive/zip"
+	"bytes"
 	"errors"
+	"io"
+	"strings"
 	"testing"
 )
 
@@ -66,5 +69,121 @@ func TestValidateCompliance_MissingPhysicalFile(t *testing.T) {
 	}
 	if missing.Href != "item/image/p-001.jpg" {
 		t.Fatalf("unexpected missing href: %s", missing.Href)
+	}
+}
+
+func TestPreflightEncode_FlexibleReturnsNil(t *testing.T) {
+	doc := &Document{Assets: map[string]*Asset{
+		"baddir/foo.jpg": {ID: "x", MimeType: "image/jpeg", Size: 100},
+	}}
+	warnings := preflightEncode(LevelFlexible, doc)
+	if warnings != nil {
+		t.Fatalf("expected nil, got: %v", warnings)
+	}
+}
+
+func TestPreflightEncode_NilDocReturnsNil(t *testing.T) {
+	warnings := preflightEncode(LevelKADOKAWA, nil)
+	if warnings != nil {
+		t.Fatalf("expected nil for nil doc, got: %v", warnings)
+	}
+}
+
+func TestPreflightEncode_ImageFileSizeWarning(t *testing.T) {
+	doc := &Document{Assets: map[string]*Asset{
+		"item/image/p-001.jpg": {
+			ID: "p-001", MimeType: "image/jpeg", Size: 5 * 1024 * 1024,
+			Open: func() (io.ReadCloser, error) {
+				return io.NopCloser(bytes.NewReader([]byte("fake"))), nil
+			},
+		},
+	}}
+	warnings := preflightEncode(LevelEBPAJ, doc)
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "file size") && strings.Contains(w, "exceeds") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected file-size warning, got: %v", warnings)
+	}
+}
+
+func TestPreflightEncode_ImageNamingWarning(t *testing.T) {
+	doc := &Document{Assets: map[string]*Asset{
+		"item/image/BADNAME.jpg": {
+			ID: "p-001", MimeType: "image/jpeg", Size: 100,
+			Open: func() (io.ReadCloser, error) {
+				return io.NopCloser(bytes.NewReader([]byte("fake"))), nil
+			},
+		},
+	}}
+	for _, level := range []ComplianceLevel{LevelEBPAJ, LevelKADOKAWA} {
+		warnings := preflightEncode(level, doc)
+		found := false
+		for _, w := range warnings {
+			if strings.Contains(w, "naming pattern") {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("level %d: expected naming warning, got: %v", level, warnings)
+		}
+	}
+}
+
+func TestPreflightEncode_DirectoryLayoutWarning(t *testing.T) {
+	doc := &Document{Assets: map[string]*Asset{
+		"wrong/place.jpg": {
+			ID: "p-001", MimeType: "image/jpeg", Size: 100,
+			Open: func() (io.ReadCloser, error) {
+				return io.NopCloser(bytes.NewReader([]byte("fake"))), nil
+			},
+		},
+	}}
+	warnings := preflightEncode(LevelKADOKAWA, doc)
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "directory layout") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected directory-layout warning, got: %v", warnings)
+	}
+}
+
+func TestPreflightEncode_XHTMLSizeWarning(t *testing.T) {
+	doc := &Document{Assets: map[string]*Asset{
+		"item/xhtml/page.xhtml": {
+			ID: "x-001", MimeType: "application/xhtml+xml", Size: 300 * 1024,
+		},
+	}}
+	warnings := preflightEncode(LevelEBPAJ, doc)
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "XHTML") && strings.Contains(w, "exceeds") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected XHTML size warning, got: %v", warnings)
+	}
+}
+
+func TestPreflightEncode_ValidDocNoWarnings(t *testing.T) {
+	png := testPNGBytes()
+	doc := &Document{Assets: map[string]*Asset{
+		"item/image/p-001.png": {
+			ID: "p-001", MimeType: "image/png", Size: uint64(len(png)),
+			Open: func() (io.ReadCloser, error) {
+				return io.NopCloser(bytes.NewReader(png)), nil
+			},
+		},
+	}}
+	warnings := preflightEncode(LevelKADOKAWA, doc)
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings for valid doc, got: %v", warnings)
 	}
 }

--- a/encode.go
+++ b/encode.go
@@ -23,13 +23,35 @@ const (
 type EncodeOption func(*encodeConfig)
 
 type encodeConfig struct {
-	generateLegacyTOC bool
+	generateLegacyTOC   bool
+	preflightCompliance ComplianceLevel
+	warningCollector    func(string)
 }
 
 // WithLegacyTOC enables generation of EPUB 2 toc.ncx alongside EPUB 3 navigation.
 func WithLegacyTOC() EncodeOption {
 	return func(cfg *encodeConfig) {
 		cfg.generateLegacyTOC = true
+	}
+}
+
+// WithEncodePreflightCompliance enables preflight compliance checks before
+// writing the EPUB ZIP.  Only strict profiles (LevelEBPAJ, LevelKADOKAWA) run
+// actual checks; LevelFlexible is accepted but performs no validation.
+// Detected violations are delivered as non-fatal warnings through the collector
+// registered via [WithEncodeWarningCollector].
+func WithEncodePreflightCompliance(level ComplianceLevel) EncodeOption {
+	return func(cfg *encodeConfig) {
+		cfg.preflightCompliance = level
+	}
+}
+
+// WithEncodeWarningCollector registers a callback that receives each preflight
+// warning string.  The callback is invoked synchronously before ZIP writing
+// begins.  If no collector is set, preflight warnings are silently discarded.
+func WithEncodeWarningCollector(fn func(string)) EncodeOption {
+	return func(cfg *encodeConfig) {
+		cfg.warningCollector = fn
 	}
 }
 
@@ -42,6 +64,16 @@ func Encode(w io.Writer, doc *Document, opts ...EncodeOption) error {
 	for _, opt := range opts {
 		opt(&cfg)
 	}
+
+	if cfg.preflightCompliance != LevelFlexible {
+		warnings := preflightEncode(cfg.preflightCompliance, doc)
+		if cfg.warningCollector != nil {
+			for _, w := range warnings {
+				cfg.warningCollector(w)
+			}
+		}
+	}
+
 	zw := zip.NewWriter(w)
 
 	if err := writeMimetype(zw); err != nil {

--- a/encode_test.go
+++ b/encode_test.go
@@ -519,3 +519,200 @@ func TestSetCover(t *testing.T) {
 		t.Fatal("no page with PageTypeCover found after decode")
 	}
 }
+
+func TestEncode_WithPreflightCompliance_NoWarningsForValidDoc(t *testing.T) {
+	doc := &Document{
+		Metadata:  Metadata{Title: "Valid"},
+		Direction: "rtl",
+		Layout:    LayoutPrePaginated,
+	}
+	png := testPNGBytes()
+	if _, _, err := doc.AddPageWithAsset(bytes.NewReader(png), int64(len(png)), "right"); err != nil {
+		t.Fatalf("AddPageWithAsset failed: %v", err)
+	}
+
+	var warnings []string
+	var out bytes.Buffer
+	err := Encode(&out, doc,
+		WithEncodePreflightCompliance(LevelKADOKAWA),
+		WithEncodeWarningCollector(func(w string) { warnings = append(warnings, w) }),
+	)
+	if err != nil {
+		t.Fatalf("Encode failed: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings, got: %v", warnings)
+	}
+}
+
+func TestEncode_WithPreflightCompliance_ImageSizeWarning(t *testing.T) {
+	doc := &Document{
+		Metadata:  Metadata{Title: "Large Image"},
+		Direction: "rtl",
+		Layout:    LayoutPrePaginated,
+		Assets: map[string]*Asset{
+			"item/image/p-001.jpg": {
+				ID:       "p-001",
+				MimeType: "image/jpeg",
+				Size:     5 * 1024 * 1024, // 5MB, exceeds 4MB limit
+				Open: func() (io.ReadCloser, error) {
+					return io.NopCloser(bytes.NewReader([]byte("fake"))), nil
+				},
+			},
+		},
+		Pages: []*Page{{Order: 0, AssetID: "p-001", Spread: "right"}},
+	}
+
+	var warnings []string
+	var out bytes.Buffer
+	err := Encode(&out, doc,
+		WithEncodePreflightCompliance(LevelEBPAJ),
+		WithEncodeWarningCollector(func(w string) { warnings = append(warnings, w) }),
+	)
+	if err != nil {
+		t.Fatalf("Encode failed: %v", err)
+	}
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "file size") && strings.Contains(w, "exceeds") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected file-size warning, got: %v", warnings)
+	}
+}
+
+func TestEncode_WithPreflightCompliance_DirectoryLayoutWarning(t *testing.T) {
+	doc := &Document{
+		Metadata:  Metadata{Title: "Bad Layout"},
+		Direction: "rtl",
+		Layout:    LayoutPrePaginated,
+		Assets: map[string]*Asset{
+			"baddir/p-001.jpg": {
+				ID:       "p-001",
+				MimeType: "image/jpeg",
+				Size:     100,
+				Open: func() (io.ReadCloser, error) {
+					return io.NopCloser(bytes.NewReader([]byte("fake"))), nil
+				},
+			},
+		},
+		Pages: []*Page{{Order: 0, AssetID: "p-001", Spread: "right"}},
+	}
+
+	var warnings []string
+	var out bytes.Buffer
+	err := Encode(&out, doc,
+		WithEncodePreflightCompliance(LevelKADOKAWA),
+		WithEncodeWarningCollector(func(w string) { warnings = append(warnings, w) }),
+	)
+	if err != nil {
+		t.Fatalf("Encode failed: %v", err)
+	}
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "directory layout") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected directory-layout warning, got: %v", warnings)
+	}
+}
+
+func TestEncode_WithPreflightCompliance_NamingWarning(t *testing.T) {
+	doc := &Document{
+		Metadata:  Metadata{Title: "Bad Naming"},
+		Direction: "rtl",
+		Layout:    LayoutPrePaginated,
+		Assets: map[string]*Asset{
+			"item/image/BADNAME.jpg": {
+				ID:       "p-001",
+				MimeType: "image/jpeg",
+				Size:     100,
+				Open: func() (io.ReadCloser, error) {
+					return io.NopCloser(bytes.NewReader([]byte("fake"))), nil
+				},
+			},
+		},
+		Pages: []*Page{{Order: 0, AssetID: "p-001", Spread: "right"}},
+	}
+
+	var warnings []string
+	var out bytes.Buffer
+	err := Encode(&out, doc,
+		WithEncodePreflightCompliance(LevelEBPAJ),
+		WithEncodeWarningCollector(func(w string) { warnings = append(warnings, w) }),
+	)
+	if err != nil {
+		t.Fatalf("Encode failed: %v", err)
+	}
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "naming pattern") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected naming-pattern warning, got: %v", warnings)
+	}
+}
+
+func TestEncode_WithPreflightCompliance_FlexibleNoWarnings(t *testing.T) {
+	doc := &Document{
+		Metadata:  Metadata{Title: "Flexible"},
+		Direction: "rtl",
+		Layout:    LayoutPrePaginated,
+		Assets: map[string]*Asset{
+			"baddir/BADNAME.jpg": {
+				ID:       "p-001",
+				MimeType: "image/jpeg",
+				Size:     100,
+				Open: func() (io.ReadCloser, error) {
+					return io.NopCloser(bytes.NewReader([]byte("fake"))), nil
+				},
+			},
+		},
+		Pages: []*Page{{Order: 0, AssetID: "p-001", Spread: "right"}},
+	}
+
+	var warnings []string
+	var out bytes.Buffer
+	err := Encode(&out, doc,
+		WithEncodePreflightCompliance(LevelFlexible),
+		WithEncodeWarningCollector(func(w string) { warnings = append(warnings, w) }),
+	)
+	if err != nil {
+		t.Fatalf("Encode failed: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("flexible mode should produce no warnings, got: %v", warnings)
+	}
+}
+
+func TestEncode_WithPreflightCompliance_NoCollectorDiscards(t *testing.T) {
+	doc := &Document{
+		Metadata:  Metadata{Title: "No Collector"},
+		Direction: "rtl",
+		Layout:    LayoutPrePaginated,
+		Assets: map[string]*Asset{
+			"baddir/BADNAME.jpg": {
+				ID:       "p-001",
+				MimeType: "image/jpeg",
+				Size:     100,
+				Open: func() (io.ReadCloser, error) {
+					return io.NopCloser(bytes.NewReader([]byte("fake"))), nil
+				},
+			},
+		},
+		Pages: []*Page{{Order: 0, AssetID: "p-001", Spread: "right"}},
+	}
+
+	var out bytes.Buffer
+	// Preflight enabled but no collector — should not panic.
+	err := Encode(&out, doc, WithEncodePreflightCompliance(LevelKADOKAWA))
+	if err != nil {
+		t.Fatalf("Encode failed: %v", err)
+	}
+}

--- a/testdata_test.go
+++ b/testdata_test.go
@@ -200,3 +200,93 @@ func TestTestdata_CoverImageRoundTrip(t *testing.T) {
 		})
 	}
 }
+
+func TestTestdata_KADOKAWAPreflightNoWarnings(t *testing.T) {
+	paths := testdataEPUBs(t)
+	if len(paths) == 0 {
+		t.Skip("no epub files in testdata/ (see testdata/README.md)")
+	}
+	for _, p := range paths {
+		base := filepath.Base(p)
+		if !strings.Contains(base, "kadokawa") {
+			continue
+		}
+		// sizecheck EPUBs intentionally violate constraints; tested separately.
+		if strings.Contains(base, "sizecheck") {
+			continue
+		}
+		t.Run(base, func(t *testing.T) {
+			f, err := os.Open(p)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer f.Close()
+
+			st, err := f.Stat()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			doc, err := epub.Decode(f, st.Size(), epub.WithCompliance(epub.LevelKADOKAWA))
+			if err != nil {
+				t.Fatalf("Decode failed: %v", err)
+			}
+
+			var warnings []string
+			var buf bytes.Buffer
+			if err := epub.Encode(&buf, doc,
+				epub.WithEncodePreflightCompliance(epub.LevelKADOKAWA),
+				epub.WithEncodeWarningCollector(func(w string) { warnings = append(warnings, w) }),
+			); err != nil {
+				t.Fatalf("Encode failed: %v", err)
+			}
+			if len(warnings) != 0 {
+				t.Errorf("expected no preflight warnings for compliant EPUB, got: %v", warnings)
+			}
+		})
+	}
+}
+
+func TestTestdata_SizecheckPreflightWarnings(t *testing.T) {
+	paths := testdataEPUBs(t)
+	if len(paths) == 0 {
+		t.Skip("no epub files in testdata/ (see testdata/README.md)")
+	}
+	for _, p := range paths {
+		base := filepath.Base(p)
+		if !strings.Contains(base, "sizecheck") {
+			continue
+		}
+		t.Run(base, func(t *testing.T) {
+			f, err := os.Open(p)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer f.Close()
+
+			st, err := f.Stat()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Decode without compliance to get the Document.
+			doc, err := epub.Decode(f, st.Size())
+			if err != nil {
+				t.Fatalf("Decode failed: %v", err)
+			}
+
+			var warnings []string
+			var buf bytes.Buffer
+			if err := epub.Encode(&buf, doc,
+				epub.WithEncodePreflightCompliance(epub.LevelKADOKAWA),
+				epub.WithEncodeWarningCollector(func(w string) { warnings = append(warnings, w) }),
+			); err != nil {
+				t.Fatalf("Encode failed: %v", err)
+			}
+			if len(warnings) == 0 {
+				t.Fatal("expected preflight warnings for sizecheck EPUB, got none")
+			}
+			t.Logf("preflight warnings (%d): %v", len(warnings), warnings)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Add optional preflight compliance warnings that run before `Encode` writes the EPUB ZIP, giving users early feedback on strict-profile violations.

## Changes

### New Encode Options (`encode.go`)
- `WithEncodePreflightCompliance(level)` — enables preflight checks for EBPAJ/KADOKAWA profiles
- `WithEncodeWarningCollector(func(string))` — registers a callback to receive warning strings

### Preflight Validator (`compliance.go`)
- `preflightEncode()` — checks Document assets before ZIP writing:
  - Directory layout violations
  - Image naming pattern mismatches (EBPAJ/KADOKAWA)
  - Image file size exceeding 4MB limit
  - Image pixel count exceeding 4M pixels
  - Progressive JPEG detection
  - XHTML file size exceeding 256KB
- `preflightImageSpecs()` — opens image assets to validate pixel count and JPEG encoding
- `isProgressiveJPEG()` — extracted helper for SOF2 marker detection

### Tests
- Unit tests for `preflightEncode` covering each rule category (`compliance_test.go`)
- Integration tests for `Encode` with preflight options (`encode_test.go`)
- Testdata integration: KADOKAWA-compliant EPUBs produce zero warnings; sizecheck EPUBs produce expected warnings (`testdata_test.go`)

## Design
- **Non-breaking**: default `Encode` behavior is unchanged
- **Warning-only**: preflight never returns errors or blocks encoding
- **Opt-in**: activated only when both options are provided
- **Reuses existing rules**: naming patterns, size constants, and directory rules are shared with decode-side compliance

Closes #25