### PR TITLE
refactor: build all XML output via encoding/xml instead of fmt.Sprintf

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -4,7 +4,6 @@ package epub
 
 import (
 	"archive/zip"
-	"bytes"
 	"encoding/xml"
 	"fmt"
 	"io"
@@ -103,13 +102,18 @@ func writeContainer(zw *zip.Writer) error {
 	if err != nil {
 		return err
 	}
-	container := `<?xml version="1.0" encoding="UTF-8"?>
-<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
-  <rootfiles>
-    <rootfile full-path="item/standard.opf" media-type="application/oebps-package+xml"/>
-  </rootfiles>
-</container>`
-	_, err = io.WriteString(w, container)
+	c := containerXML{
+		Rootfiles: containerRootfiles{
+			Rootfile: []containerRootfile{
+				{FullPath: "item/standard.opf", MediaType: "application/oebps-package+xml"},
+			},
+		},
+	}
+	b, err := xml.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return err
+	}
+	_, err = io.WriteString(w, xml.Header+string(b))
 	return err
 }
 
@@ -128,8 +132,8 @@ func writePackageAndAssets(zw *zip.Writer, doc *Document, cfg encodeConfig) erro
 
 	coverAssetID := resolveCoverAssetID(doc, assetPaths)
 
-	manifestItems := make([]string, 0, len(assetPaths))
 	opfDir := "item"
+	items := make([]manifestItem, 0, len(assetPaths)+2)
 	for _, p := range assetPaths {
 		a := doc.Assets[p]
 		href := p
@@ -140,51 +144,34 @@ func writePackageAndAssets(zw *zip.Writer, doc *Document, cfg encodeConfig) erro
 		if coverAssetID != "" && a.ID == coverAssetID {
 			item.Properties = "cover-image"
 		}
-		b, err := xml.Marshal(item)
-		if err != nil {
-			return err
-		}
-		manifestItems = append(manifestItems, string(b))
+		items = append(items, item)
 	}
-	navItemBytes, err := xml.Marshal(manifestItem{ID: "nav", Href: navHref, MediaType: "application/xhtml+xml", Properties: "nav"})
-	if err != nil {
-		return err
-	}
-	manifestItems = append(manifestItems, string(navItemBytes))
+	items = append(items, manifestItem{ID: "nav", Href: navHref, MediaType: "application/xhtml+xml", Properties: "nav"})
 	if cfg.generateLegacyTOC {
-		ncxItemBytes, err := xml.Marshal(manifestItem{ID: "ncx", Href: "toc.ncx", MediaType: "application/x-dtbncx+xml"})
-		if err != nil {
-			return err
-		}
-		manifestItems = append(manifestItems, string(ncxItemBytes))
+		items = append(items, manifestItem{ID: "ncx", Href: "toc.ncx", MediaType: "application/x-dtbncx+xml"})
 	}
 
-	spineItems := make([]string, 0, len(doc.Pages))
+	spineItems := make([]spineItem, 0, len(doc.Pages))
 	for _, pg := range doc.Pages {
-		prop := spreadToProperty(pg.Spread)
-		if prop == "" {
-			spineItems = append(spineItems, fmt.Sprintf(`<itemref idref=%q/>`, xmlEscape(pg.AssetID)))
-			continue
-		}
-		spineItems = append(spineItems, fmt.Sprintf(`<itemref idref=%q properties=%q/>`, xmlEscape(pg.AssetID), xmlEscape(prop)))
+		spineItems = append(spineItems, spineItem{
+			IDRef:      pg.AssetID,
+			Properties: spreadToProperty(pg.Spread),
+		})
 	}
 
 	rLayout := "reflowable"
 	if doc.Layout == LayoutPrePaginated {
 		rLayout = "pre-paginated"
 	}
-	spineTOC := ""
-	if cfg.generateLegacyTOC {
-		spineTOC = ` toc="ncx"`
-	}
 
-	metadataEntries := []string{
-		fmt.Sprintf(`<dc:title id="title">%s</dc:title>`, xmlEscape(metadata.Title)),
-		fmt.Sprintf(`<dc:identifier id=%q>%s</dc:identifier>`, xmlEscape(identifierID), xmlEscape(identifier)),
-	}
+	titles := []dcElement{{ID: "title", Value: metadata.Title}}
+	identifiers := []dcElement{{ID: identifierID, Value: identifier}}
+
+	var creators []dcElement
+	var metaEntries []metadataMeta
 
 	if v := strings.TrimSpace(metadata.TitleFileAs); v != "" {
-		metadataEntries = append(metadataEntries, fmt.Sprintf(`<meta property="file-as" refines="#title">%s</meta>`, xmlEscape(v)))
+		metaEntries = append(metaEntries, metadataMeta{Property: "file-as", Refines: "#title", Value: v})
 	}
 	for i, creator := range metadata.Creators {
 		name := strings.TrimSpace(creator.Name)
@@ -192,50 +179,61 @@ func writePackageAndAssets(zw *zip.Writer, doc *Document, cfg encodeConfig) erro
 			continue
 		}
 		creatorID := fmt.Sprintf("creator-%d", i+1)
-		metadataEntries = append(metadataEntries, fmt.Sprintf(`<dc:creator id=%q>%s</dc:creator>`, xmlEscape(creatorID), xmlEscape(name)))
+		creators = append(creators, dcElement{ID: creatorID, Value: name})
 		if v := strings.TrimSpace(creator.FileAs); v != "" {
-			metadataEntries = append(metadataEntries, fmt.Sprintf(`<meta property="file-as" refines=%q>%s</meta>`, xmlEscape("#"+creatorID), xmlEscape(v)))
+			metaEntries = append(metaEntries, metadataMeta{Property: "file-as", Refines: "#" + creatorID, Value: v})
 		}
 	}
 
 	if coverAssetID != "" {
-		coverMetaBytes, err := xml.Marshal(metadataMeta{Name: "cover", Content: coverAssetID})
-		if err != nil {
-			return err
-		}
-		metadataEntries = append(metadataEntries, string(coverMetaBytes))
+		metaEntries = append(metaEntries, metadataMeta{Name: "cover", Content: coverAssetID})
 	}
 
 	rSpread := normalizeRenditionSpread(metadata.RenditionSpread)
 	rOrientation := normalizeRenditionOrientation(metadata.RenditionOrientation)
 
-	metadataEntries = append(metadataEntries,
-		fmt.Sprintf(`<meta property="rendition:layout">%s</meta>`, xmlEscape(rLayout)),
-		fmt.Sprintf(`<meta property="rendition:spread">%s</meta>`, xmlEscape(rSpread)),
-		fmt.Sprintf(`<meta property="rendition:orientation">%s</meta>`, xmlEscape(rOrientation)),
-		fmt.Sprintf(`<meta property="dcterms:modified">%s</meta>`, xmlEscape(formatW3CTime(time.Now()))),
-		fmt.Sprintf(`<meta property="ebpaj:guide-version">%s</meta>`, xmlEscape(normalizeSpecVersion(metadata.EBPAJGuideVersion, defaultEBPAJGuideVersion))),
-		fmt.Sprintf(`<meta property="kadokawa:version">%s</meta>`, xmlEscape(normalizeSpecVersion(metadata.KADOKAWAVersion, defaultKADOKAWAVersion))),
+	metaEntries = append(metaEntries,
+		metadataMeta{Property: "rendition:layout", Value: rLayout},
+		metadataMeta{Property: "rendition:spread", Value: rSpread},
+		metadataMeta{Property: "rendition:orientation", Value: rOrientation},
+		metadataMeta{Property: "dcterms:modified", Value: formatW3CTime(time.Now())},
+		metadataMeta{Property: "ebpaj:guide-version", Value: normalizeSpecVersion(metadata.EBPAJGuideVersion, defaultEBPAJGuideVersion)},
+		metadataMeta{Property: "kadokawa:version", Value: normalizeSpecVersion(metadata.KADOKAWAVersion, defaultKADOKAWAVersion)},
 	)
 
-	opf := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
-<package version="3.0" xmlns="http://www.idpf.org/2007/opf" unique-identifier=%q prefix="rendition: http://www.idpf.org/vocab/rendition/# dcterms: http://purl.org/dc/terms/ ebpaj: https://www.ebpaj.jp/ kadokawa: https://www.kadokawa.co.jp/">
-  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-    %s
-  </metadata>
-  <manifest>
-    %s
-  </manifest>
-  <spine page-progression-direction=%q%s>
-    %s
-  </spine>
-</package>`, xmlEscape(identifierID), strings.Join(metadataEntries, "\n    "), strings.Join(manifestItems, "\n    "), xmlEscape(normalizeDirection(doc.Direction)), spineTOC, strings.Join(spineItems, "\n    "))
+	spineTOC := ""
+	if cfg.generateLegacyTOC {
+		spineTOC = "ncx"
+	}
+
+	pkg := packageXML{
+		Version:          "3.0",
+		UniqueIdentifier: identifierID,
+		Prefix:           "rendition: http://www.idpf.org/vocab/rendition/# dcterms: http://purl.org/dc/terms/ ebpaj: https://www.ebpaj.jp/ kadokawa: https://www.kadokawa.co.jp/",
+		Metadata: packageMetadata{
+			Titles:      titles,
+			Identifiers: identifiers,
+			Creators:    creators,
+			Meta:        metaEntries,
+		},
+		Manifest: packageManifest{Items: items},
+		Spine: packageSpine{
+			PageProgressionDirection: normalizeDirection(doc.Direction),
+			TOC:                      spineTOC,
+			Itemrefs:                 spineItems,
+		},
+	}
+
+	b, err := xml.MarshalIndent(pkg, "", "  ")
+	if err != nil {
+		return err
+	}
 
 	w, err := zw.Create("item/standard.opf")
 	if err != nil {
 		return err
 	}
-	if _, err := io.WriteString(w, opf); err != nil {
+	if _, err := io.WriteString(w, xml.Header+string(b)); err != nil {
 		return err
 	}
 
@@ -252,7 +250,10 @@ func writePackageAndAssets(zw *zip.Writer, doc *Document, cfg encodeConfig) erro
 	}
 
 	if cfg.generateLegacyTOC {
-		ncx := buildLegacyNCX(doc, identifier)
+		ncx, err := buildLegacyNCX(doc, identifier)
+		if err != nil {
+			return err
+		}
 		ncxW, err := zw.Create("item/toc.ncx")
 		if err != nil {
 			return err
@@ -297,12 +298,6 @@ func spreadToProperty(spread string) string {
 	default:
 		return ""
 	}
-}
-
-func xmlEscape(v string) string {
-	var b bytes.Buffer
-	xml.EscapeText(&b, []byte(v))
-	return b.String()
 }
 
 func normalizeIdentifier(v string) string {
@@ -477,30 +472,43 @@ func buildNavigationDocument(doc *Document, navHref string, coverAssetID string)
 	return xml.Header + string(b), nil
 }
 
-func buildLegacyNCX(doc *Document, identifier string) string {
+func buildLegacyNCX(doc *Document, identifier string) (string, error) {
 	metadata := doc.effectiveMetadata()
 
-	navPoints := make([]string, 0, len(doc.Pages))
+	navPoints := make([]ncxNavPoint, 0, len(doc.Pages))
 	for i, pg := range doc.Pages {
 		href := strings.TrimSpace(pg.Href)
 		href = strings.TrimPrefix(cleanOPFRef("item", href), "item/")
 		if href == "" {
 			href = "#"
 		}
-		navPoints = append(navPoints, fmt.Sprintf(`<navPoint id="navPoint-%d" playOrder="%d"><navLabel><text>Page %d</text></navLabel><content src=%q/></navPoint>`, i+1, i+1, i+1, xmlEscape(href)))
+		navPoints = append(navPoints, ncxNavPoint{
+			ID:        fmt.Sprintf("navPoint-%d", i+1),
+			PlayOrder: i + 1,
+			NavLabel:  ncxNavLabel{Text: fmt.Sprintf("Page %d", i+1)},
+			Content:   ncxContent{Src: href},
+		})
 	}
 	if len(navPoints) == 0 {
-		navPoints = append(navPoints, `<navPoint id="navPoint-1" playOrder="1"><navLabel><text>Start</text></navLabel><content src="#"/></navPoint>`)
+		navPoints = append(navPoints, ncxNavPoint{
+			ID:        "navPoint-1",
+			PlayOrder: 1,
+			NavLabel:  ncxNavLabel{Text: "Start"},
+			Content:   ncxContent{Src: "#"},
+		})
 	}
 
-	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
-<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1">
-  <head>
-    <meta name="dtb:uid" content=%q/>
-  </head>
-  <docTitle><text>%s</text></docTitle>
-  <navMap>
-    %s
-  </navMap>
-</ncx>`, xmlEscape(identifier), xmlEscape(metadata.Title), strings.Join(navPoints, "\n    "))
+	ncx := ncxDocument{
+		Head: ncxHead{
+			Metas: []ncxMeta{{Name: "dtb:uid", Content: identifier}},
+		},
+		DocTitle: ncxDocTitle{Text: metadata.Title},
+		NavMap:   ncxNavMap{NavPoints: navPoints},
+	}
+
+	b, err := xml.MarshalIndent(ncx, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return xml.Header + string(b), nil
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -154,7 +154,7 @@ func TestEncode_WithLegacyTOC_GeneratesNCXWithMatchingUID(t *testing.T) {
 	}
 
 	ncxContent := readZipEntry(t, out.Bytes(), "item/toc.ncx")
-	if !strings.Contains(ncxContent, `<meta name="dtb:uid" content="E-2026-0002"/>`) {
+	if !strings.Contains(ncxContent, `<meta name="dtb:uid" content="E-2026-0002"></meta>`) {
 		t.Fatalf("ncx dtb:uid mismatch: %s", ncxContent)
 	}
 }

--- a/xml_types.go
+++ b/xml_types.go
@@ -9,6 +9,21 @@ type containerXML struct {
 	Rootfiles containerRootfiles `xml:"rootfiles"`
 }
 
+func (c containerXML) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	start.Name = xml.Name{Local: "container"}
+	start.Attr = []xml.Attr{
+		{Name: xml.Name{Local: "version"}, Value: "1.0"},
+		{Name: xml.Name{Local: "xmlns"}, Value: "urn:oasis:names:tc:opendocument:xmlns:container"},
+	}
+	if err := e.EncodeToken(start); err != nil {
+		return err
+	}
+	if err := e.EncodeElement(c.Rootfiles, xml.StartElement{Name: xml.Name{Local: "rootfiles"}}); err != nil {
+		return err
+	}
+	return e.EncodeToken(start.End())
+}
+
 type containerRootfiles struct {
 	Rootfile []containerRootfile `xml:"rootfile"`
 }
@@ -20,10 +35,35 @@ type containerRootfile struct {
 
 type packageXML struct {
 	XMLName          xml.Name        `xml:"package"`
+	Version          string          `xml:"version,attr,omitempty"`
 	UniqueIdentifier string          `xml:"unique-identifier,attr"`
+	Prefix           string          `xml:"prefix,attr,omitempty"`
 	Metadata         packageMetadata `xml:"metadata"`
 	Manifest         packageManifest `xml:"manifest"`
 	Spine            packageSpine    `xml:"spine"`
+}
+
+func (p packageXML) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	start.Name = xml.Name{Local: "package"}
+	start.Attr = []xml.Attr{
+		{Name: xml.Name{Local: "version"}, Value: p.Version},
+		{Name: xml.Name{Local: "xmlns"}, Value: "http://www.idpf.org/2007/opf"},
+		{Name: xml.Name{Local: "unique-identifier"}, Value: p.UniqueIdentifier},
+		{Name: xml.Name{Local: "prefix"}, Value: p.Prefix},
+	}
+	if err := e.EncodeToken(start); err != nil {
+		return err
+	}
+	if err := e.EncodeElement(p.Metadata, xml.StartElement{Name: xml.Name{Local: "metadata"}}); err != nil {
+		return err
+	}
+	if err := e.EncodeElement(p.Manifest, xml.StartElement{Name: xml.Name{Local: "manifest"}}); err != nil {
+		return err
+	}
+	if err := e.EncodeElement(p.Spine, xml.StartElement{Name: xml.Name{Local: "spine"}}); err != nil {
+		return err
+	}
+	return e.EncodeToken(start.End())
 }
 
 type packageMetadata struct {
@@ -31,6 +71,51 @@ type packageMetadata struct {
 	Identifiers []dcElement    `xml:"identifier"`
 	Creators    []dcElement    `xml:"creator"`
 	Meta        []metadataMeta `xml:"meta"`
+}
+
+func (m packageMetadata) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	start.Name = xml.Name{Local: "metadata"}
+	start.Attr = []xml.Attr{
+		{Name: xml.Name{Local: "xmlns:dc"}, Value: "http://purl.org/dc/elements/1.1/"},
+	}
+	if err := e.EncodeToken(start); err != nil {
+		return err
+	}
+	for _, t := range m.Titles {
+		if err := encodeDCElement(e, "dc:title", t); err != nil {
+			return err
+		}
+	}
+	for _, id := range m.Identifiers {
+		if err := encodeDCElement(e, "dc:identifier", id); err != nil {
+			return err
+		}
+	}
+	for _, c := range m.Creators {
+		if err := encodeDCElement(e, "dc:creator", c); err != nil {
+			return err
+		}
+	}
+	for _, meta := range m.Meta {
+		if err := e.EncodeElement(meta, xml.StartElement{Name: xml.Name{Local: "meta"}}); err != nil {
+			return err
+		}
+	}
+	return e.EncodeToken(start.End())
+}
+
+func encodeDCElement(e *xml.Encoder, name string, dc dcElement) error {
+	start := xml.StartElement{Name: xml.Name{Local: name}}
+	if dc.ID != "" {
+		start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "id"}, Value: dc.ID})
+	}
+	if err := e.EncodeToken(start); err != nil {
+		return err
+	}
+	if err := e.EncodeToken(xml.CharData(dc.Value)); err != nil {
+		return err
+	}
+	return e.EncodeToken(start.End())
 }
 
 type dcElement struct {
@@ -61,12 +146,32 @@ type manifestItem struct {
 
 type packageSpine struct {
 	PageProgressionDirection string      `xml:"page-progression-direction,attr"`
+	TOC                      string      `xml:"toc,attr,omitempty"`
 	Itemrefs                 []spineItem `xml:"itemref"`
+}
+
+func (s packageSpine) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	start.Name = xml.Name{Local: "spine"}
+	start.Attr = []xml.Attr{
+		{Name: xml.Name{Local: "page-progression-direction"}, Value: s.PageProgressionDirection},
+	}
+	if s.TOC != "" {
+		start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "toc"}, Value: s.TOC})
+	}
+	if err := e.EncodeToken(start); err != nil {
+		return err
+	}
+	for _, item := range s.Itemrefs {
+		if err := e.EncodeElement(item, xml.StartElement{Name: xml.Name{Local: "itemref"}}); err != nil {
+			return err
+		}
+	}
+	return e.EncodeToken(start.End())
 }
 
 type spineItem struct {
 	IDRef      string `xml:"idref,attr"`
-	Properties string `xml:"properties,attr"`
+	Properties string `xml:"properties,attr,omitempty"`
 }
 
 type xhtmlMeta struct {
@@ -224,4 +329,68 @@ func (li navListItem) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 		return err
 	}
 	return e.EncodeToken(start.End())
+}
+
+// NCX types for EPUB 2 toc.ncx generation.
+
+type ncxDocument struct {
+	Head     ncxHead
+	DocTitle ncxDocTitle
+	NavMap   ncxNavMap
+}
+
+func (n ncxDocument) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	start.Name = xml.Name{Local: "ncx"}
+	start.Attr = []xml.Attr{
+		{Name: xml.Name{Local: "xmlns"}, Value: "http://www.daisy.org/z3986/2005/ncx/"},
+		{Name: xml.Name{Local: "version"}, Value: "2005-1"},
+	}
+	if err := e.EncodeToken(start); err != nil {
+		return err
+	}
+	if err := e.EncodeElement(n.Head, xml.StartElement{Name: xml.Name{Local: "head"}}); err != nil {
+		return err
+	}
+	if err := e.EncodeElement(n.DocTitle, xml.StartElement{Name: xml.Name{Local: "docTitle"}}); err != nil {
+		return err
+	}
+	if err := e.EncodeElement(n.NavMap, xml.StartElement{Name: xml.Name{Local: "navMap"}}); err != nil {
+		return err
+	}
+	return e.EncodeToken(start.End())
+}
+
+type ncxHead struct {
+	Metas []ncxMeta `xml:"meta"`
+}
+
+type ncxMeta struct {
+	XMLName xml.Name `xml:"meta"`
+	Name    string   `xml:"name,attr"`
+	Content string   `xml:"content,attr"`
+}
+
+type ncxDocTitle struct {
+	Text string `xml:"text"`
+}
+
+type ncxNavMap struct {
+	NavPoints []ncxNavPoint `xml:"navPoint"`
+}
+
+type ncxNavPoint struct {
+	XMLName   xml.Name    `xml:"navPoint"`
+	ID        string      `xml:"id,attr"`
+	PlayOrder int         `xml:"playOrder,attr"`
+	NavLabel  ncxNavLabel `xml:"navLabel"`
+	Content   ncxContent  `xml:"content"`
+}
+
+type ncxNavLabel struct {
+	Text string `xml:"text"`
+}
+
+type ncxContent struct {
+	XMLName xml.Name `xml:"content"`
+	Src     string   `xml:"src,attr"`
 }


### PR DESCRIPTION
## Summary

Migrate all XML construction in `encode.go` to use `encoding/xml` (`xml.MarshalIndent`) with struct types defined in `xml_types.go`, eliminating manual `fmt.Sprintf` + `xmlEscape()` patterns.

## Changes

### `xml_types.go`
- Add `MarshalXML` methods to `containerXML`, `packageXML`, `packageMetadata`, `packageSpine` for namespace/attribute control
- Add `Version`, `Prefix` fields to `packageXML`; `TOC` field to `packageSpine`
- Add `omitempty` to `spineItem.Properties`
- Add helper `encodeDCElement` for `dc:`-prefixed elements
- Add NCX struct types: `ncxDocument` (with `MarshalXML`), `ncxHead`, `ncxMeta`, `ncxDocTitle`, `ncxNavMap`, `ncxNavPoint`, `ncxNavLabel`, `ncxContent`

### `encode.go`
- `writeContainer`: hardcoded string literal → `xml.MarshalIndent(containerXML{...})`
- `writePackageAndAssets`: `fmt.Sprintf` template → `packageXML` struct + `xml.MarshalIndent`
- `buildLegacyNCX`: `fmt.Sprintf` template → `ncxDocument` struct + `xml.MarshalIndent`; return type changed to `(string, error)`
- Remove `xmlEscape()` helper and `bytes` import

### `encode_test.go`
- Update NCX meta assertion: `/>` → `></meta>` (`encoding/xml` uses closing tags for empty elements)

Closes #31