### PR TITLE
feat: add required dc:language to OPF metadata

### DIFF
--- a/cmd/epub/main.go
+++ b/cmd/epub/main.go
@@ -78,6 +78,7 @@ func runInspect(args []string) error {
 	}
 
 	fmt.Printf("Title: %s\n", doc.Metadata.Title)
+	fmt.Printf("Language: %s\n", doc.Metadata.Language)
 	fmt.Printf("Direction: %s\n", doc.Direction)
 	fmt.Printf("Layout: %s\n", doc.Layout.String())
 	fmt.Printf("Pages: %d\n", len(doc.Pages))
@@ -229,6 +230,7 @@ func runBuildFromImages(args []string) error {
 	spread := fs.String("spread", "right", "left|right|center|none (left/right alternate automatically)")
 	globPattern := fs.String("glob", "", "glob pattern for images (e.g. ./images/*.jpg)")
 	cover := fs.String("cover", "", "path to cover image (added as first page with cover semantics)")
+	language := fs.String("language", "en", "dc:language value (e.g. ja, en, zh-Hans)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -269,7 +271,7 @@ func runBuildFromImages(args []string) error {
 	}
 
 	doc := &epub.Document{
-		Metadata:  epub.Metadata{Title: strings.TrimSpace(*title)},
+		Metadata:  epub.Metadata{Title: strings.TrimSpace(*title), Language: strings.TrimSpace(*language)},
 		Direction: directionNorm,
 		Layout:    layoutType,
 		Pages:     make([]*epub.Page, 0, len(imagePaths)),
@@ -469,7 +471,7 @@ Usage:
   epub inspect      -in book.epub [-compliance flexible|ebpaj|kadokawa]
 	epub repack       -in book.epub -out out.epub [-compliance flexible|ebpaj|kadokawa] [-legacy-toc]
   epub images       -in book.epub [-mode pages|all] [-json] [-compliance flexible|ebpaj|kadokawa]
-	epub build-images -out out.epub [-title TITLE] [-compliance flexible|ebpaj|kadokawa] [-legacy-toc] [-direction rtl|ltr] [-layout pre-paginated|reflowable]
+	epub build-images -out out.epub [-title TITLE] [-language LANG] [-compliance flexible|ebpaj|kadokawa] [-legacy-toc] [-direction rtl|ltr] [-layout pre-paginated|reflowable]
 					[-spread left|right|center|none] [-cover cover.jpg] [-glob './images/*.jpg'] [image1 image2 ...]
 `)
 }

--- a/decode.go
+++ b/decode.go
@@ -103,6 +103,7 @@ func Decode(r io.ReaderAt, size int64, opts ...DecodeOption) (*Document, error) 
 
 	title, titleID := primaryDCValue(pkg.Metadata.Titles)
 	identifier, identifierID := primaryIdentifier(pkg.Metadata.Identifiers, pkg.UniqueIdentifier)
+	language, _ := primaryDCValue(pkg.Metadata.Languages)
 	fileAsByRefines := parseFileAsByRefines(pkg.Metadata.Meta)
 
 	titleFileAs := ""
@@ -116,6 +117,7 @@ func Decode(r io.ReaderAt, size int64, opts ...DecodeOption) (*Document, error) 
 			TitleFileAs:          titleFileAs,
 			Identifier:           identifier,
 			IdentifierID:         identifierID,
+			Language:             language,
 			Creators:             parseCreators(pkg.Metadata.Creators, fileAsByRefines),
 			CoverAssetID:         parseCoverAssetID(normalizedManifest, pkg.Metadata.Meta),
 			RenditionSpread:      parseMetaValueByProperty(pkg.Metadata.Meta, "rendition:spread"),

--- a/encode.go
+++ b/encode.go
@@ -166,6 +166,7 @@ func writePackageAndAssets(zw *zip.Writer, doc *Document, cfg encodeConfig) erro
 
 	titles := []dcElement{{ID: "title", Value: metadata.Title}}
 	identifiers := []dcElement{{ID: identifierID, Value: identifier}}
+	languages := []dcElement{{Value: metadata.Language}}
 
 	var creators []dcElement
 	var metaEntries []metadataMeta
@@ -213,6 +214,7 @@ func writePackageAndAssets(zw *zip.Writer, doc *Document, cfg encodeConfig) erro
 		Metadata: packageMetadata{
 			Titles:      titles,
 			Identifiers: identifiers,
+			Languages:   languages,
 			Creators:    creators,
 			Meta:        metaEntries,
 		},

--- a/encode_test.go
+++ b/encode_test.go
@@ -716,3 +716,72 @@ func TestEncode_WithPreflightCompliance_NoCollectorDiscards(t *testing.T) {
 		t.Fatalf("Encode failed: %v", err)
 	}
 }
+
+func TestEncode_LanguageDefault(t *testing.T) {
+	doc := &Document{
+		Metadata:  Metadata{Title: "Lang Default"},
+		Direction: "rtl",
+		Layout:    LayoutPrePaginated,
+	}
+	png := testPNGBytes()
+	if _, _, err := doc.AddPageWithAsset(bytes.NewReader(png), int64(len(png)), "right"); err != nil {
+		t.Fatalf("AddPageWithAsset failed: %v", err)
+	}
+
+	var out bytes.Buffer
+	if err := Encode(&out, doc); err != nil {
+		t.Fatalf("Encode failed: %v", err)
+	}
+
+	opfContent := readZipEntry(t, out.Bytes(), "item/standard.opf")
+	if !strings.Contains(opfContent, `<dc:language>en</dc:language>`) {
+		t.Fatalf("dc:language default missing:\n%s", opfContent)
+	}
+}
+
+func TestEncode_LanguageExplicit(t *testing.T) {
+	doc := &Document{
+		Metadata:  Metadata{Title: "Lang Explicit", Language: "ja"},
+		Direction: "rtl",
+		Layout:    LayoutPrePaginated,
+	}
+	png := testPNGBytes()
+	if _, _, err := doc.AddPageWithAsset(bytes.NewReader(png), int64(len(png)), "right"); err != nil {
+		t.Fatalf("AddPageWithAsset failed: %v", err)
+	}
+
+	var out bytes.Buffer
+	if err := Encode(&out, doc); err != nil {
+		t.Fatalf("Encode failed: %v", err)
+	}
+
+	opfContent := readZipEntry(t, out.Bytes(), "item/standard.opf")
+	if !strings.Contains(opfContent, `<dc:language>ja</dc:language>`) {
+		t.Fatalf("dc:language explicit missing:\n%s", opfContent)
+	}
+}
+
+func TestEncodeDecode_LanguageRoundTrip(t *testing.T) {
+	doc := &Document{
+		Metadata:  Metadata{Title: "Lang RoundTrip", Language: "zh-Hans"},
+		Direction: "ltr",
+		Layout:    LayoutPrePaginated,
+	}
+	png := testPNGBytes()
+	if _, _, err := doc.AddPageWithAsset(bytes.NewReader(png), int64(len(png)), "right"); err != nil {
+		t.Fatalf("AddPageWithAsset failed: %v", err)
+	}
+
+	var out bytes.Buffer
+	if err := Encode(&out, doc); err != nil {
+		t.Fatalf("Encode failed: %v", err)
+	}
+
+	decoded, err := Decode(bytes.NewReader(out.Bytes()), int64(out.Len()))
+	if err != nil {
+		t.Fatalf("Decode failed: %v", err)
+	}
+	if decoded.Metadata.Language != "zh-Hans" {
+		t.Fatalf("Language mismatch: got %q, want %q", decoded.Metadata.Language, "zh-Hans")
+	}
+}

--- a/epub.go
+++ b/epub.go
@@ -44,6 +44,7 @@ type Metadata struct {
 	TitleFileAs          string
 	Identifier           string
 	IdentifierID         string
+	Language             string
 	Creators             []Creator
 	CoverAssetID         string
 	RenditionSpread      string
@@ -68,6 +69,9 @@ func (d *Document) effectiveMetadata() Metadata {
 	}
 	if strings.TrimSpace(m.Identifier) == "" {
 		m.Identifier = d.Identifier
+	}
+	if strings.TrimSpace(m.Language) == "" {
+		m.Language = "en"
 	}
 	return m
 }

--- a/xml_types.go
+++ b/xml_types.go
@@ -69,6 +69,7 @@ func (p packageXML) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 type packageMetadata struct {
 	Titles      []dcElement    `xml:"title"`
 	Identifiers []dcElement    `xml:"identifier"`
+	Languages   []dcElement    `xml:"language"`
 	Creators    []dcElement    `xml:"creator"`
 	Meta        []metadataMeta `xml:"meta"`
 }
@@ -88,6 +89,11 @@ func (m packageMetadata) MarshalXML(e *xml.Encoder, start xml.StartElement) erro
 	}
 	for _, id := range m.Identifiers {
 		if err := encodeDCElement(e, "dc:identifier", id); err != nil {
+			return err
+		}
+	}
+	for _, l := range m.Languages {
+		if err := encodeDCElement(e, "dc:language", l); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary

Add the required `<dc:language>` element to OPF metadata to pass Kindle/EpubCheck validation.

## Changes

- **`epub.go`**: Add `Language` field to `Metadata` struct; fallback to `"en"` in `effectiveMetadata()`
- **`xml_types.go`**: Add `Languages` to `packageMetadata`; encode `<dc:language>` in `MarshalXML`
- **`encode.go`**: Populate languages slice for OPF generation
- **`decode.go`**: Parse `<dc:language>` into `Metadata.Language`
- **`encode_test.go`**: Tests for default (`"en"`), explicit, and round-trip
- **`cmd/epub/main.go`**: Add `-language` flag to `build-images`; display `Language` in `inspect`

Closes #33