### PR TITLE
fix: resolve all golangci-lint v2 issues and add lint to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,12 @@ jobs:
       - name: Run vet
         run: go vet ./...
 
+      - name: Run golangci-lint
+        if: matrix.go-version == 'stable'
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        with:
+          version: v2.11.4
+
       - name: Run tests (oldstable)
         if: matrix.go-version == 'oldstable'
         run: go test ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,16 @@
+version: "2"
+
+linters:
+  default: standard
+  enable:
+    - bodyclose
+    - copyloopvar
+    - errname
+    - errorlint
+    - fatcontext
+    - gocritic
+    - nilerr
+    - unconvert
+    - unparam
+    - usestdlibvars
+    - wastedassign

--- a/cmd/epub/main.go
+++ b/cmd/epub/main.go
@@ -66,7 +66,7 @@ func runInspect(args []string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	level, err := parseCompliance(*compliance)
 	if err != nil {
@@ -133,7 +133,7 @@ func runListImages(args []string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	level, err := parseCompliance(*compliance)
 	if err != nil {
@@ -314,7 +314,7 @@ func runBuildFromImages(args []string) error {
 	if err != nil {
 		return err
 	}
-	defer outFile.Close()
+	defer func() { _ = outFile.Close() }()
 
 	encodeOpts := make([]epub.EncodeOption, 0, 1)
 	if *legacyTOC {
@@ -332,7 +332,7 @@ func runBuildFromImages(args []string) error {
 	if err != nil {
 		return err
 	}
-	defer verifyFile.Close()
+	defer func() { _ = verifyFile.Close() }()
 	if _, err := epub.Decode(verifyFile, verifySize, epub.WithCompliance(level)); err != nil {
 		return fmt.Errorf("generated epub failed %s compliance validation: %w", strings.ToLower(strings.TrimSpace(*compliance)), err)
 	}
@@ -358,7 +358,7 @@ func runRepack(args []string) error {
 	if err != nil {
 		return err
 	}
-	defer inFile.Close()
+	defer func() { _ = inFile.Close() }()
 
 	level, err := parseCompliance(*compliance)
 	if err != nil {
@@ -373,7 +373,7 @@ func runRepack(args []string) error {
 	if err != nil {
 		return err
 	}
-	defer outFile.Close()
+	defer func() { _ = outFile.Close() }()
 
 	encodeOpts := make([]epub.EncodeOption, 0, 1)
 	if *legacyTOC {
@@ -394,7 +394,7 @@ func openReaderAt(path string) (*os.File, int64, error) {
 	}
 	st, err := f.Stat()
 	if err != nil {
-		f.Close()
+		_ = f.Close()
 		return nil, 0, err
 	}
 	return f, st.Size(), nil

--- a/compliance.go
+++ b/compliance.go
@@ -37,7 +37,7 @@ func validateCompliance(level ComplianceLevel, files map[string]struct{}, manife
 
 	for href, item := range manifest {
 		if _, ok := files[href]; !ok {
-			return nil, &DecodeError{Path: href, Rule: "manifest-physical-existence", Err: &ErrManifestPhysicalMissing{Href: href}}
+			return nil, &DecodeError{Path: href, Rule: "manifest-physical-existence", Err: &ManifestPhysicalMissingError{Href: href}}
 		}
 		if err := validateDirectoryRule(href); err != nil {
 			return nil, err
@@ -118,7 +118,7 @@ func validateImageSpecs(zf *zip.File, href string) error {
 		return &DecodeError{
 			Path: href,
 			Rule: "image-file-size",
-			Err: &ErrImageFileSizeTooLarge{
+			Err: &ImageFileSizeTooLargeError{
 				Href:   href,
 				Limit:  maxImageFileSize,
 				Actual: int64(zf.UncompressedSize64),
@@ -131,7 +131,7 @@ func validateImageSpecs(zf *zip.File, href string) error {
 	if err != nil {
 		return &DecodeError{Path: href, Rule: "image-open", Err: err}
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 
 	// Read all data to check pixel count and JPEG properties
 	data, err := io.ReadAll(rc)
@@ -151,7 +151,7 @@ func validateImageSpecs(zf *zip.File, href string) error {
 		return &DecodeError{
 			Path: href,
 			Rule: "image-pixel-count",
-			Err: &ErrImagePixelCountExceeded{
+			Err: &ImagePixelCountExceededError{
 				Href:   href,
 				Limit:  maxImagePixelCount,
 				Actual: pixelCount,
@@ -175,7 +175,7 @@ func validateJPEGSpecs(r io.Reader, href string) error {
 	// Progressive JPEG has SOF2 marker (0xFFC2) instead of SOF0 (0xFFC0)
 	data, err := io.ReadAll(r)
 	if err != nil {
-		return nil // Skip validation if we can't read
+		return nil //nolint:nilerr // Skip validation if we can't read
 	}
 
 	if len(data) > 5 {
@@ -186,7 +186,7 @@ func validateJPEGSpecs(r io.Reader, href string) error {
 				return &DecodeError{
 					Path: href,
 					Rule: "jpeg-progressive",
-					Err:  &ErrProgressiveJPEGNotAllowed{Href: href},
+					Err:  &ProgressiveJPEGNotAllowedError{Href: href},
 				}
 			}
 		}
@@ -261,7 +261,7 @@ func preflightImageSpecs(href string, asset *Asset) []string {
 	if err != nil {
 		return nil
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 
 	data, err := io.ReadAll(rc)
 	if err != nil {

--- a/compliance_test.go
+++ b/compliance_test.go
@@ -63,9 +63,9 @@ func TestValidateCompliance_MissingPhysicalFile(t *testing.T) {
 	if de.Rule != "manifest-physical-existence" {
 		t.Fatalf("unexpected rule: %s", de.Rule)
 	}
-	var missing *ErrManifestPhysicalMissing
+	var missing *ManifestPhysicalMissingError
 	if !errors.As(err, &missing) {
-		t.Fatalf("expected ErrManifestPhysicalMissing, got: %v", err)
+		t.Fatalf("expected ManifestPhysicalMissingError, got: %v", err)
 	}
 	if missing.Href != "item/image/p-001.jpg" {
 		t.Fatalf("unexpected missing href: %s", missing.Href)

--- a/decode.go
+++ b/decode.go
@@ -137,7 +137,7 @@ func Decode(r io.ReaderAt, size int64, opts ...DecodeOption) (*Document, error) 
 	for _, item := range normalizedManifest {
 		zfile, ok := filesByName[item.Href]
 		if !ok {
-			return nil, &DecodeError{Path: item.Href, Rule: "manifest-physical-existence", Err: &ErrManifestPhysicalMissing{Href: item.Href}}
+			return nil, &DecodeError{Path: item.Href, Rule: "manifest-physical-existence", Err: &ManifestPhysicalMissingError{Href: item.Href}}
 		}
 		current := zfile
 		asset := &Asset{
@@ -157,7 +157,7 @@ func Decode(r io.ReaderAt, size int64, opts ...DecodeOption) (*Document, error) 
 	for i, ref := range pkg.Spine.Itemrefs {
 		item, ok := manifestByID[ref.IDRef]
 		if !ok {
-			return nil, &DecodeError{Path: opfPath, Rule: "spine-idref", Err: &ErrSpineUnknownIDRef{IDRef: ref.IDRef}}
+			return nil, &DecodeError{Path: opfPath, Rule: "spine-idref", Err: &SpineUnknownIDRefError{IDRef: ref.IDRef}}
 		}
 		page := &Page{Order: i, AssetID: item.ID, Href: item.Href, Spread: spreadFromProperties(ref.Properties)}
 		if doc.IsPrePaginated() && strings.Contains(item.MediaType, "xhtml") {
@@ -218,7 +218,7 @@ func validateMimeType(zr *zip.Reader) error {
 	if err != nil {
 		return &DecodeError{Path: "mimetype", Rule: "mimetype-read", Err: err}
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 	buf, err := io.ReadAll(rc)
 	if err != nil {
 		return &DecodeError{Path: "mimetype", Rule: "mimetype-read", Err: err}
@@ -238,7 +238,7 @@ func readOPFPath(files map[string]*zip.File) (string, error) {
 	if err != nil {
 		return "", &DecodeError{Path: "META-INF/container.xml", Rule: "container-read", Err: err}
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 
 	var c containerXML
 	if err := xml.NewDecoder(rc).Decode(&c); err != nil {
@@ -263,7 +263,7 @@ func readPackageXML(files map[string]*zip.File, opfPath string) (*packageXML, er
 	if err != nil {
 		return nil, &DecodeError{Path: opfPath, Rule: "opf-read", Err: err}
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 
 	var pkg packageXML
 	if err := xml.NewDecoder(rc).Decode(&pkg); err != nil {
@@ -275,13 +275,13 @@ func readPackageXML(files map[string]*zip.File, opfPath string) (*packageXML, er
 func readViewport(files map[string]*zip.File, href string) (int, int, error) {
 	f, ok := files[href]
 	if !ok {
-		return 0, 0, &DecodeError{Path: href, Rule: "viewport-file", Err: &ErrManifestPhysicalMissing{Href: href}}
+		return 0, 0, &DecodeError{Path: href, Rule: "viewport-file", Err: &ManifestPhysicalMissingError{Href: href}}
 	}
 	rc, err := f.Open()
 	if err != nil {
 		return 0, 0, &DecodeError{Path: href, Rule: "viewport-read", Err: err}
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 	buf, err := io.ReadAll(rc)
 	if err != nil {
 		return 0, 0, &DecodeError{Path: href, Rule: "viewport-read", Err: err}
@@ -470,23 +470,12 @@ func cleanOPFRef(opfDir, href string) string {
 	return strings.TrimPrefix(joined, "./")
 }
 
-func wrapPathErr(path string, rule string, err error) error {
-	if err == nil {
-		return nil
-	}
-	var de *DecodeError
-	if errors.As(err, &de) {
-		return err
-	}
-	return &DecodeError{Path: path, Rule: rule, Err: fmt.Errorf("%w", err)}
-}
-
 func validateResourceLimits(zr *zip.Reader, cfg decodeConfig) error {
 	if cfg.maxAssetCount > 0 && len(zr.File) > cfg.maxAssetCount {
 		return &DecodeError{
 			Path: "zip",
 			Rule: "max-asset-count",
-			Err:  &ErrMaxAssetCountExceeded{Limit: cfg.maxAssetCount, Actual: len(zr.File)},
+			Err:  &MaxAssetCountExceededError{Limit: cfg.maxAssetCount, Actual: len(zr.File)},
 		}
 	}
 
@@ -497,7 +486,7 @@ func validateResourceLimits(zr *zip.Reader, cfg decodeConfig) error {
 			return &DecodeError{
 				Path: f.Name,
 				Rule: "max-individual-asset-size",
-				Err:  &ErrMaxIndividualAssetSizeExceeded{Name: f.Name, Limit: cfg.maxIndividualAssetSize, Actual: size},
+				Err:  &MaxIndividualAssetSizeExceededError{Name: f.Name, Limit: cfg.maxIndividualAssetSize, Actual: size},
 			}
 		}
 
@@ -506,7 +495,7 @@ func validateResourceLimits(zr *zip.Reader, cfg decodeConfig) error {
 			return &DecodeError{
 				Path: "zip",
 				Rule: "max-total-uncompressed-size",
-				Err:  &ErrMaxTotalUncompressedSizeExceeded{Limit: cfg.maxTotalUncompressedSize, Actual: total},
+				Err:  &MaxTotalUncompressedSizeExceededError{Limit: cfg.maxTotalUncompressedSize, Actual: total},
 			}
 		}
 	}

--- a/decode_test.go
+++ b/decode_test.go
@@ -256,9 +256,9 @@ func TestDecode_MissingManifestPhysicalFileStructuredError(t *testing.T) {
 	if de.Rule != "manifest-physical-existence" {
 		t.Fatalf("unexpected rule: %s", de.Rule)
 	}
-	var missing *ErrManifestPhysicalMissing
+	var missing *ManifestPhysicalMissingError
 	if !errors.As(err, &missing) {
-		t.Fatalf("expected ErrManifestPhysicalMissing, got: %v", err)
+		t.Fatalf("expected ManifestPhysicalMissingError, got: %v", err)
 	}
 	if missing.Href != "item/image/p-001.jpg" {
 		t.Fatalf("unexpected missing href: %s", missing.Href)
@@ -278,9 +278,9 @@ func TestDecode_UnknownSpineIDRefStructuredError(t *testing.T) {
 	if de.Rule != "spine-idref" {
 		t.Fatalf("unexpected rule: %s", de.Rule)
 	}
-	var unknown *ErrSpineUnknownIDRef
+	var unknown *SpineUnknownIDRefError
 	if !errors.As(err, &unknown) {
-		t.Fatalf("expected ErrSpineUnknownIDRef, got: %v", err)
+		t.Fatalf("expected SpineUnknownIDRefError, got: %v", err)
 	}
 	if unknown.IDRef != "missing-item" {
 		t.Fatalf("unexpected missing idref: %s", unknown.IDRef)
@@ -302,9 +302,9 @@ func TestDecode_WithMaxAssetCount_Exceeded(t *testing.T) {
 		t.Fatalf("unexpected rule: %s", de.Rule)
 	}
 
-	var exceeded *ErrMaxAssetCountExceeded
+	var exceeded *MaxAssetCountExceededError
 	if !errors.As(err, &exceeded) {
-		t.Fatalf("expected ErrMaxAssetCountExceeded, got: %v", err)
+		t.Fatalf("expected MaxAssetCountExceededError, got: %v", err)
 	}
 	if exceeded.Limit != 3 {
 		t.Fatalf("unexpected limit: %d", exceeded.Limit)
@@ -326,9 +326,9 @@ func TestDecode_WithMaxTotalUncompressedSize_Exceeded(t *testing.T) {
 		t.Fatalf("unexpected rule: %s", de.Rule)
 	}
 
-	var exceeded *ErrMaxTotalUncompressedSizeExceeded
+	var exceeded *MaxTotalUncompressedSizeExceededError
 	if !errors.As(err, &exceeded) {
-		t.Fatalf("expected ErrMaxTotalUncompressedSizeExceeded, got: %v", err)
+		t.Fatalf("expected MaxTotalUncompressedSizeExceededError, got: %v", err)
 	}
 	if exceeded.Limit != 200 {
 		t.Fatalf("unexpected limit: %d", exceeded.Limit)
@@ -350,9 +350,9 @@ func TestDecode_WithMaxIndividualAssetSize_Exceeded(t *testing.T) {
 		t.Fatalf("unexpected rule: %s", de.Rule)
 	}
 
-	var exceeded *ErrMaxIndividualAssetSizeExceeded
+	var exceeded *MaxIndividualAssetSizeExceededError
 	if !errors.As(err, &exceeded) {
-		t.Fatalf("expected ErrMaxIndividualAssetSizeExceeded, got: %v", err)
+		t.Fatalf("expected MaxIndividualAssetSizeExceededError, got: %v", err)
 	}
 	if exceeded.Limit != 200 {
 		t.Fatalf("unexpected limit: %d", exceeded.Limit)
@@ -382,9 +382,8 @@ func makeMinimalEPUB(t *testing.T, cfg minimalEPUBConfig) []byte {
 		cfg.spineIDRef = "xhtml-1"
 	}
 	manifestImageHref := strings.TrimPrefix(cfg.imageHref, "item/")
-	if !cfg.mimetypeFirst && cfg.mimetypeDeflate {
-		// allowed; this helper intentionally supports both toggles
-	}
+	// Both !mimetypeFirst && mimetypeDeflate is allowed;
+	// this helper intentionally supports both toggles.
 
 	layout := "reflowable"
 	if cfg.prePaginated {
@@ -446,7 +445,7 @@ func makeMinimalEPUB(t *testing.T, cfg minimalEPUBConfig) []byte {
 		if cfg.mimetypeDeflate {
 			method = zip.Deflate
 		}
-		w, err := zw.CreateHeader(&zip.FileHeader{Name: "mimetype", Method: uint16(method)})
+		w, err := zw.CreateHeader(&zip.FileHeader{Name: "mimetype", Method: method})
 		if err != nil {
 			t.Fatalf("create mimetype: %v", err)
 		}

--- a/encode.go
+++ b/encode.go
@@ -279,7 +279,7 @@ func writePackageAndAssets(zw *zip.Writer, doc *Document, cfg encodeConfig) erro
 			return err
 		}
 		if _, err := io.Copy(aw, rc); err != nil {
-			rc.Close()
+			_ = rc.Close()
 			return err
 		}
 		if err := rc.Close(); err != nil {

--- a/encode_test.go
+++ b/encode_test.go
@@ -310,7 +310,7 @@ func readZipEntry(t *testing.T, data []byte, name string) string {
 		if err != nil {
 			t.Fatalf("open zip entry %s failed: %v", name, err)
 		}
-		defer rc.Close()
+		defer func() { _ = rc.Close() }()
 		b, err := io.ReadAll(rc)
 		if err != nil {
 			t.Fatalf("read zip entry %s failed: %v", name, err)

--- a/epub.go
+++ b/epub.go
@@ -540,7 +540,7 @@ func (a *Asset) CalculateHash() error {
 	if err != nil {
 		return err
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 
 	h := sha256.New()
 	if _, err := io.Copy(h, rc); err != nil {
@@ -577,7 +577,7 @@ func extractImageRefsFromAsset(asset *Asset) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 
 	buf, err := io.ReadAll(rc)
 	if err != nil {

--- a/epub_test.go
+++ b/epub_test.go
@@ -86,7 +86,7 @@ func TestAddPageWithAssetGeneratesXHTMLWrapper(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open wrapper failed: %v", err)
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 	body, err := io.ReadAll(rc)
 	if err != nil {
 		t.Fatalf("read wrapper failed: %v", err)

--- a/errors.go
+++ b/errors.go
@@ -57,84 +57,84 @@ var (
 	errInvalidDirectoryLayout = errors.New("asset path must be under item/xhtml, item/image, or item/style")
 )
 
-// ErrSpineUnknownIDRef is returned when a spine itemref points to an unknown manifest ID.
-type ErrSpineUnknownIDRef struct {
+// SpineUnknownIDRefError is returned when a spine itemref points to an unknown manifest ID.
+type SpineUnknownIDRefError struct {
 	IDRef string
 }
 
-func (e *ErrSpineUnknownIDRef) Error() string {
+func (e *SpineUnknownIDRefError) Error() string {
 	if e == nil || e.IDRef == "" {
 		return "spine itemref references unknown manifest id"
 	}
 	return fmt.Sprintf("spine itemref references unknown manifest id %q", e.IDRef)
 }
 
-func (e *ErrSpineUnknownIDRef) Is(target error) bool {
-	_, ok := target.(*ErrSpineUnknownIDRef)
+func (e *SpineUnknownIDRefError) Is(target error) bool {
+	_, ok := target.(*SpineUnknownIDRefError)
 	return ok
 }
 
-// ErrManifestPhysicalMissing is returned when a manifest item href does not exist in the ZIP.
-type ErrManifestPhysicalMissing struct {
+// ManifestPhysicalMissingError is returned when a manifest item href does not exist in the ZIP.
+type ManifestPhysicalMissingError struct {
 	Href string
 }
 
-func (e *ErrManifestPhysicalMissing) Error() string {
+func (e *ManifestPhysicalMissingError) Error() string {
 	if e == nil || e.Href == "" {
 		return "manifest item href does not exist in ZIP"
 	}
 	return fmt.Sprintf("manifest item href %q does not exist in ZIP", e.Href)
 }
 
-func (e *ErrManifestPhysicalMissing) Is(target error) bool {
-	_, ok := target.(*ErrManifestPhysicalMissing)
+func (e *ManifestPhysicalMissingError) Is(target error) bool {
+	_, ok := target.(*ManifestPhysicalMissingError)
 	return ok
 }
 
-// ErrMaxAssetCountExceeded is returned when ZIP entry count exceeds configured limit.
-type ErrMaxAssetCountExceeded struct {
+// MaxAssetCountExceededError is returned when ZIP entry count exceeds configured limit.
+type MaxAssetCountExceededError struct {
 	Limit  int
 	Actual int
 }
 
-func (e *ErrMaxAssetCountExceeded) Error() string {
+func (e *MaxAssetCountExceededError) Error() string {
 	if e == nil {
 		return "zip entry count exceeds configured limit"
 	}
 	return fmt.Sprintf("zip entry count exceeds configured limit: actual=%d limit=%d", e.Actual, e.Limit)
 }
 
-func (e *ErrMaxAssetCountExceeded) Is(target error) bool {
-	_, ok := target.(*ErrMaxAssetCountExceeded)
+func (e *MaxAssetCountExceededError) Is(target error) bool {
+	_, ok := target.(*MaxAssetCountExceededError)
 	return ok
 }
 
-// ErrMaxTotalUncompressedSizeExceeded is returned when total ZIP uncompressed size exceeds configured limit.
-type ErrMaxTotalUncompressedSizeExceeded struct {
+// MaxTotalUncompressedSizeExceededError is returned when total ZIP uncompressed size exceeds configured limit.
+type MaxTotalUncompressedSizeExceededError struct {
 	Limit  int64
 	Actual uint64
 }
 
-func (e *ErrMaxTotalUncompressedSizeExceeded) Error() string {
+func (e *MaxTotalUncompressedSizeExceededError) Error() string {
 	if e == nil {
 		return "total uncompressed size exceeds configured limit"
 	}
 	return fmt.Sprintf("total uncompressed size exceeds configured limit: actual=%d limit=%d", e.Actual, e.Limit)
 }
 
-func (e *ErrMaxTotalUncompressedSizeExceeded) Is(target error) bool {
-	_, ok := target.(*ErrMaxTotalUncompressedSizeExceeded)
+func (e *MaxTotalUncompressedSizeExceededError) Is(target error) bool {
+	_, ok := target.(*MaxTotalUncompressedSizeExceededError)
 	return ok
 }
 
-// ErrMaxIndividualAssetSizeExceeded is returned when a ZIP entry uncompressed size exceeds configured limit.
-type ErrMaxIndividualAssetSizeExceeded struct {
+// MaxIndividualAssetSizeExceededError is returned when a ZIP entry uncompressed size exceeds configured limit.
+type MaxIndividualAssetSizeExceededError struct {
 	Name   string
 	Limit  int64
 	Actual uint64
 }
 
-func (e *ErrMaxIndividualAssetSizeExceeded) Error() string {
+func (e *MaxIndividualAssetSizeExceededError) Error() string {
 	if e == nil {
 		return "individual uncompressed size exceeds configured limit"
 	}
@@ -144,8 +144,8 @@ func (e *ErrMaxIndividualAssetSizeExceeded) Error() string {
 	return fmt.Sprintf("individual uncompressed size exceeds configured limit for %q: actual=%d limit=%d", e.Name, e.Actual, e.Limit)
 }
 
-func (e *ErrMaxIndividualAssetSizeExceeded) Is(target error) bool {
-	_, ok := target.(*ErrMaxIndividualAssetSizeExceeded)
+func (e *MaxIndividualAssetSizeExceededError) Is(target error) bool {
+	_, ok := target.(*MaxIndividualAssetSizeExceededError)
 	return ok
 }
 
@@ -165,76 +165,76 @@ func (e *DecodeError) Error() string {
 
 func (e *DecodeError) Unwrap() error { return e.Err }
 
-// ErrImagePixelCountExceeded is returned when image pixel count exceeds the limit.
-type ErrImagePixelCountExceeded struct {
+// ImagePixelCountExceededError is returned when image pixel count exceeds the limit.
+type ImagePixelCountExceededError struct {
 	Href   string
 	Limit  int64
 	Actual int64
 }
 
-func (e *ErrImagePixelCountExceeded) Error() string {
+func (e *ImagePixelCountExceededError) Error() string {
 	if e == nil || e.Href == "" {
 		return "image pixel count exceeds limit"
 	}
 	return fmt.Sprintf("image %q pixel count exceeds limit: %d > %d", e.Href, e.Actual, e.Limit)
 }
 
-func (e *ErrImagePixelCountExceeded) Is(target error) bool {
-	_, ok := target.(*ErrImagePixelCountExceeded)
+func (e *ImagePixelCountExceededError) Is(target error) bool {
+	_, ok := target.(*ImagePixelCountExceededError)
 	return ok
 }
 
-// ErrImageFileSizeTooLarge is returned when image file size exceeds the limit.
-type ErrImageFileSizeTooLarge struct {
+// ImageFileSizeTooLargeError is returned when image file size exceeds the limit.
+type ImageFileSizeTooLargeError struct {
 	Href   string
 	Limit  int64
 	Actual int64
 }
 
-func (e *ErrImageFileSizeTooLarge) Error() string {
+func (e *ImageFileSizeTooLargeError) Error() string {
 	if e == nil || e.Href == "" {
 		return "image file size exceeds limit"
 	}
 	return fmt.Sprintf("image %q file size exceeds limit: %d > %d bytes", e.Href, e.Actual, e.Limit)
 }
 
-func (e *ErrImageFileSizeTooLarge) Is(target error) bool {
-	_, ok := target.(*ErrImageFileSizeTooLarge)
+func (e *ImageFileSizeTooLargeError) Is(target error) bool {
+	_, ok := target.(*ImageFileSizeTooLargeError)
 	return ok
 }
 
-// ErrProgressiveJPEGNotAllowed is returned when a progressive JPEG is detected.
-type ErrProgressiveJPEGNotAllowed struct {
+// ProgressiveJPEGNotAllowedError is returned when a progressive JPEG is detected.
+type ProgressiveJPEGNotAllowedError struct {
 	Href string
 }
 
-func (e *ErrProgressiveJPEGNotAllowed) Error() string {
+func (e *ProgressiveJPEGNotAllowedError) Error() string {
 	if e == nil || e.Href == "" {
 		return "progressive JPEG is not allowed"
 	}
 	return fmt.Sprintf("image %q: progressive JPEG is not allowed", e.Href)
 }
 
-func (e *ErrProgressiveJPEGNotAllowed) Is(target error) bool {
-	_, ok := target.(*ErrProgressiveJPEGNotAllowed)
+func (e *ProgressiveJPEGNotAllowedError) Is(target error) bool {
+	_, ok := target.(*ProgressiveJPEGNotAllowedError)
 	return ok
 }
 
-// ErrInvalidColorSpace is returned when image has invalid color space.
-type ErrInvalidColorSpace struct {
+// InvalidColorSpaceError is returned when image has invalid color space.
+type InvalidColorSpaceError struct {
 	Href     string
 	Expected string
 	Actual   string
 }
 
-func (e *ErrInvalidColorSpace) Error() string {
+func (e *InvalidColorSpaceError) Error() string {
 	if e == nil || e.Href == "" {
 		return "invalid color space"
 	}
 	return fmt.Sprintf("image %q has invalid color space: expected %s, got %s", e.Href, e.Expected, e.Actual)
 }
 
-func (e *ErrInvalidColorSpace) Is(target error) bool {
-	_, ok := target.(*ErrInvalidColorSpace)
+func (e *InvalidColorSpaceError) Is(target error) bool {
+	_, ok := target.(*InvalidColorSpaceError)
 	return ok
 }

--- a/errors_example_test.go
+++ b/errors_example_test.go
@@ -18,7 +18,7 @@ func ExampleDecode_structuredErrors() {
 		return
 	}
 
-	var missing *ErrManifestPhysicalMissing
+	var missing *ManifestPhysicalMissingError
 	if errors.As(err, &missing) {
 		fmt.Println("missing", missing.Href)
 	}

--- a/testdata_test.go
+++ b/testdata_test.go
@@ -34,7 +34,7 @@ func TestTestdata_DecodeAll(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer f.Close()
+			defer func() { _ = f.Close() }()
 
 			st, err := f.Stat()
 			if err != nil {
@@ -70,7 +70,7 @@ func TestTestdata_KADOKAWACompliance(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer f.Close()
+			defer func() { _ = f.Close() }()
 
 			st, err := f.Stat()
 			if err != nil {
@@ -117,7 +117,7 @@ func TestTestdata_DPFJTemplates(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer f.Close()
+			defer func() { _ = f.Close() }()
 
 			st, err := f.Stat()
 			if err != nil {
@@ -154,7 +154,7 @@ func TestTestdata_CoverImageRoundTrip(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer f.Close()
+			defer func() { _ = f.Close() }()
 
 			st, err := f.Stat()
 			if err != nil {
@@ -220,7 +220,7 @@ func TestTestdata_KADOKAWAPreflightNoWarnings(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer f.Close()
+			defer func() { _ = f.Close() }()
 
 			st, err := f.Stat()
 			if err != nil {
@@ -262,7 +262,7 @@ func TestTestdata_SizecheckPreflightWarnings(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer f.Close()
+			defer func() { _ = f.Close() }()
 
 			st, err := f.Stat()
 			if err != nil {


### PR DESCRIPTION
## Summary

Fix all 23 issues reported by golangci-lint v2 and add a lint step to CI.

## Changes

### Lint fixes (13 files)

| Linter | Count | Fix |
|--------|-------|-----|
| errcheck | 10 | `defer x.Close()` → `defer func() { _ = x.Close() }()` |
| errname | 9 | Rename `ErrXxx` → `XxxError` (e.g. `ErrSpineUnknownIDRef` → `SpineUnknownIDRefError`) |
| nilerr | 1 | Annotate intentional nil return with `//nolint:nilerr` |
| staticcheck | 1 | Replace empty if-branch with comment |
| unconvert | 1 | Remove unnecessary `uint16()` conversion |
| unused | 1 | Remove unused `wrapPathErr` function |

### CI

- Add `golangci-lint-action@v9.2.0` step (stable matrix only)

## Breaking changes

Exported error type names have been renamed to conform to the `XxxError` convention:

- `ErrSpineUnknownIDRef` → `SpineUnknownIDRefError`
- `ErrManifestPhysicalMissing` → `ManifestPhysicalMissingError`
- `ErrMaxAssetCountExceeded` → `MaxAssetCountExceededError`
- `ErrMaxTotalUncompressedSizeExceeded` → `MaxTotalUncompressedSizeExceededError`
- `ErrMaxIndividualAssetSizeExceeded` → `MaxIndividualAssetSizeExceededError`
- `ErrImagePixelCountExceeded` → `ImagePixelCountExceededError`
- `ErrImageFileSizeTooLarge` → `ImageFileSizeTooLargeError`
- `ErrProgressiveJPEGNotAllowed` → `ProgressiveJPEGNotAllowedError`
- `ErrInvalidColorSpace` → `InvalidColorSpaceError`
