### PR TITLE
feat: support multiple compliances and extract validators to sub-packages

### DIFF
--- a/cmd/epub/main.go
+++ b/cmd/epub/main.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 
 	"github.com/publira/epub"
+	"github.com/publira/epub/profile/ebpaj"
+	"github.com/publira/epub/profile/kadokawa"
 )
 
 func main() {
@@ -68,11 +70,11 @@ func runInspect(args []string) error {
 	}
 	defer func() { _ = f.Close() }()
 
-	level, err := parseCompliance(*compliance)
+	validators, err := parseValidators(*compliance)
 	if err != nil {
 		return err
 	}
-	doc, err := epub.Decode(f, size, epub.WithCompliance(level))
+	doc, err := epub.Decode(f, size, epub.WithValidator(validators...))
 	if err != nil {
 		return err
 	}
@@ -135,11 +137,11 @@ func runListImages(args []string) error {
 	}
 	defer func() { _ = f.Close() }()
 
-	level, err := parseCompliance(*compliance)
+	validators, err := parseValidators(*compliance)
 	if err != nil {
 		return err
 	}
-	doc, err := epub.Decode(f, size, epub.WithCompliance(level))
+	doc, err := epub.Decode(f, size, epub.WithValidator(validators...))
 	if err != nil {
 		return err
 	}
@@ -238,7 +240,7 @@ func runBuildFromImages(args []string) error {
 		return fmt.Errorf("-out is required")
 	}
 
-	level, err := parseCompliance(*compliance)
+	level, err := parseValidators(*compliance)
 	if err != nil {
 		return err
 	}
@@ -333,7 +335,7 @@ func runBuildFromImages(args []string) error {
 		return err
 	}
 	defer func() { _ = verifyFile.Close() }()
-	if _, err := epub.Decode(verifyFile, verifySize, epub.WithCompliance(level)); err != nil {
+	if _, err := epub.Decode(verifyFile, verifySize, epub.WithValidator(level...)); err != nil {
 		return fmt.Errorf("generated epub failed %s compliance validation: %w", strings.ToLower(strings.TrimSpace(*compliance)), err)
 	}
 
@@ -360,11 +362,11 @@ func runRepack(args []string) error {
 	}
 	defer func() { _ = inFile.Close() }()
 
-	level, err := parseCompliance(*compliance)
+	validators, err := parseValidators(*compliance)
 	if err != nil {
 		return err
 	}
-	doc, err := epub.Decode(inFile, size, epub.WithCompliance(level))
+	doc, err := epub.Decode(inFile, size, epub.WithValidator(validators...))
 	if err != nil {
 		return err
 	}
@@ -400,16 +402,16 @@ func openReaderAt(path string) (*os.File, int64, error) {
 	return f, st.Size(), nil
 }
 
-func parseCompliance(s string) (epub.ComplianceLevel, error) {
+func parseValidators(s string) ([]epub.Validator, error) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
 	case "", "flexible":
-		return epub.LevelFlexible, nil
+		return nil, nil
 	case "ebpaj":
-		return epub.LevelEBPAJ, nil
+		return []epub.Validator{ebpaj.New()}, nil
 	case "kadokawa":
-		return epub.LevelKADOKAWA, nil
+		return []epub.Validator{kadokawa.New()}, nil
 	default:
-		return epub.LevelFlexible, fmt.Errorf("unknown compliance: %s", s)
+		return nil, fmt.Errorf("unknown compliance: %s", s)
 	}
 }
 

--- a/decode.go
+++ b/decode.go
@@ -23,7 +23,7 @@ var viewportPattern = regexp.MustCompile(`(?i)width\s*=\s*([0-9]+)\s*,\s*height\
 func Decode(r io.ReaderAt, size int64, opts ...DecodeOption) (*Document, error) {
 	cfg := defaultDecodeConfig()
 	for _, opt := range opts {
-		opt(&cfg)
+		opt.applyDecode(&cfg)
 	}
 
 	zr, err := zip.NewReader(r, size)
@@ -202,6 +202,29 @@ func Decode(r io.ReaderAt, size int64, opts ...DecodeOption) (*Document, error) 
 		}
 	}
 
+	doc.Warnings = warnings
+
+	// Run pluggable validators registered via WithValidator.
+	for _, v := range cfg.validators {
+		for _, err := range v.ValidateDocument(doc) {
+			var w *ValidationWarningError
+			if errors.As(err, &w) {
+				addWarning(w.Message)
+			} else {
+				return nil, &DecodeError{Path: "", Rule: "validator", Err: err}
+			}
+		}
+		for href, asset := range doc.Assets {
+			for _, err := range v.ValidateAsset(href, asset) {
+				var w *ValidationWarningError
+				if errors.As(err, &w) {
+					addWarning(w.Message)
+				} else {
+					return nil, &DecodeError{Path: href, Rule: "validator", Err: err}
+				}
+			}
+		}
+	}
 	doc.Warnings = warnings
 
 	return doc, nil

--- a/decode_test.go
+++ b/decode_test.go
@@ -512,3 +512,111 @@ func makeMinimalEPUB(t *testing.T, cfg minimalEPUBConfig) []byte {
 	}
 	return buf.Bytes()
 }
+
+// --- WithValidator tests ---
+
+// stubValidator is a test Validator that returns errors for specific hrefs.
+type stubValidator struct {
+	assetErrors map[string][]error
+	docErrors   []error
+}
+
+func (v *stubValidator) ValidateDocument(_ *Document) []error { return v.docErrors }
+
+func (v *stubValidator) ValidateAsset(href string, _ *Asset) []error {
+	return v.assetErrors[href]
+}
+
+func TestDecode_WithValidator_FatalError(t *testing.T) {
+	epubData := makeMinimalEPUB(t, minimalEPUBConfig{mimetypeFirst: true})
+	v := &stubValidator{
+		assetErrors: map[string][]error{
+			"item/image/p-001.jpg": {errors.New("image is bad")},
+		},
+	}
+	_, err := Decode(bytes.NewReader(epubData), int64(len(epubData)), WithValidator(v))
+	if err == nil {
+		t.Fatal("expected error from validator")
+	}
+	var de *DecodeError
+	if !errors.As(err, &de) {
+		t.Fatalf("expected DecodeError, got: %T", err)
+	}
+	if de.Rule != "validator" {
+		t.Fatalf("unexpected rule: %s", de.Rule)
+	}
+}
+
+func TestDecode_WithValidator_Warning(t *testing.T) {
+	epubData := makeMinimalEPUB(t, minimalEPUBConfig{mimetypeFirst: true})
+	v := &stubValidator{
+		assetErrors: map[string][]error{
+			"item/image/p-001.jpg": {&ValidationWarningError{Message: "soft issue"}},
+		},
+	}
+	doc, err := Decode(bytes.NewReader(epubData), int64(len(epubData)), WithValidator(v))
+	if err != nil {
+		t.Fatalf("expected no fatal error, got: %v", err)
+	}
+	found := false
+	for _, w := range doc.Warnings {
+		if strings.Contains(w, "soft issue") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected warning 'soft issue', got: %v", doc.Warnings)
+	}
+}
+
+func TestDecode_WithValidator_DocumentLevelError(t *testing.T) {
+	epubData := makeMinimalEPUB(t, minimalEPUBConfig{mimetypeFirst: true})
+	v := &stubValidator{
+		docErrors: []error{errors.New("doc-level issue")},
+	}
+	_, err := Decode(bytes.NewReader(epubData), int64(len(epubData)), WithValidator(v))
+	if err == nil {
+		t.Fatal("expected error from document-level validator")
+	}
+}
+
+func TestDecode_WithValidator_MultipleValidators(t *testing.T) {
+	epubData := makeMinimalEPUB(t, minimalEPUBConfig{mimetypeFirst: true})
+	v1 := &stubValidator{
+		assetErrors: map[string][]error{
+			"item/image/p-001.jpg": {&ValidationWarningError{Message: "warning-from-v1"}},
+		},
+	}
+	v2 := &stubValidator{
+		assetErrors: map[string][]error{
+			"item/image/p-001.jpg": {&ValidationWarningError{Message: "warning-from-v2"}},
+		},
+	}
+	doc, err := Decode(bytes.NewReader(epubData), int64(len(epubData)), WithValidator(v1, v2))
+	if err != nil {
+		t.Fatalf("expected no fatal error, got: %v", err)
+	}
+	foundV1, foundV2 := false, false
+	for _, w := range doc.Warnings {
+		if strings.Contains(w, "warning-from-v1") {
+			foundV1 = true
+		}
+		if strings.Contains(w, "warning-from-v2") {
+			foundV2 = true
+		}
+	}
+	if !foundV1 || !foundV2 {
+		t.Fatalf("expected warnings from both validators, got: %v", doc.Warnings)
+	}
+}
+
+func TestDecode_WithValidator_NoValidators(t *testing.T) {
+	epubData := makeMinimalEPUB(t, minimalEPUBConfig{mimetypeFirst: true})
+	doc, err := Decode(bytes.NewReader(epubData), int64(len(epubData)))
+	if err != nil {
+		t.Fatalf("Decode failed: %v", err)
+	}
+	if doc.Metadata.Title != "Test Book" {
+		t.Fatalf("unexpected title: %s", doc.Metadata.Title)
+	}
+}

--- a/doc.go
+++ b/doc.go
@@ -10,16 +10,27 @@
 // Key points:
 //
 //   - Fail-fast decoding with DecodeError path/rule context.
-//   - Compliance modes for flexible, EBPAJ, and KADOKAWA-oriented checks.
+//   - Pluggable [Validator] interface with profile sub-packages
+//     ([github.com/publira/epub/profile/ebpaj],
+//     [github.com/publira/epub/profile/kadokawa],
+//     [github.com/publira/epub/profile/kindle]).
 //   - Stream-first asset model via Asset.Open to avoid large in-memory blobs.
 //   - Helper methods on Document to auto-generate spec-friendly image IDs/paths.
 //
-// Basic decode example:
+// Basic decode example with validators:
+//
+//	import (
+//		"github.com/publira/epub"
+//		"github.com/publira/epub/profile/kadokawa"
+//		"github.com/publira/epub/profile/kindle"
+//	)
 //
 //	f, _ := os.Open("book.epub")
 //	defer f.Close()
 //	stat, _ := f.Stat()
-//	doc, err := epub.Decode(f, stat.Size(), epub.WithCompliance(epub.LevelEBPAJ))
+//	doc, err := epub.Decode(f, stat.Size(),
+//		epub.WithValidator(kadokawa.New(), kindle.New()),
+//	)
 //	if err != nil {
 //		// handle DecodeError
 //	}

--- a/encode.go
+++ b/encode.go
@@ -18,20 +18,18 @@ const (
 	defaultKADOKAWAVersion   = "1.0"
 )
 
-// EncodeOption mutates encode behavior.
-type EncodeOption func(*encodeConfig)
-
 type encodeConfig struct {
 	generateLegacyTOC   bool
 	preflightCompliance ComplianceLevel
+	preflightValidators []Validator
 	warningCollector    func(string)
 }
 
 // WithLegacyTOC enables generation of EPUB 2 toc.ncx alongside EPUB 3 navigation.
 func WithLegacyTOC() EncodeOption {
-	return func(cfg *encodeConfig) {
+	return encodeOptionFunc(func(cfg *encodeConfig) {
 		cfg.generateLegacyTOC = true
-	}
+	})
 }
 
 // WithEncodePreflightCompliance enables preflight compliance checks before
@@ -39,19 +37,21 @@ func WithLegacyTOC() EncodeOption {
 // actual checks; LevelFlexible is accepted but performs no validation.
 // Detected violations are delivered as non-fatal warnings through the collector
 // registered via [WithEncodeWarningCollector].
+//
+// Deprecated: Use [WithValidator] with profile sub-packages instead.
 func WithEncodePreflightCompliance(level ComplianceLevel) EncodeOption {
-	return func(cfg *encodeConfig) {
+	return encodeOptionFunc(func(cfg *encodeConfig) {
 		cfg.preflightCompliance = level
-	}
+	})
 }
 
 // WithEncodeWarningCollector registers a callback that receives each preflight
 // warning string.  The callback is invoked synchronously before ZIP writing
 // begins.  If no collector is set, preflight warnings are silently discarded.
 func WithEncodeWarningCollector(fn func(string)) EncodeOption {
-	return func(cfg *encodeConfig) {
+	return encodeOptionFunc(func(cfg *encodeConfig) {
 		cfg.warningCollector = fn
-	}
+	})
 }
 
 // Encode writes a normalized Document into EPUB ZIP stream.
@@ -61,7 +61,7 @@ func Encode(w io.Writer, doc *Document, opts ...EncodeOption) error {
 	}
 	cfg := encodeConfig{}
 	for _, opt := range opts {
-		opt(&cfg)
+		opt.applyEncode(&cfg)
 	}
 
 	if cfg.preflightCompliance != LevelFlexible {
@@ -69,6 +69,23 @@ func Encode(w io.Writer, doc *Document, opts ...EncodeOption) error {
 		if cfg.warningCollector != nil {
 			for _, w := range warnings {
 				cfg.warningCollector(w)
+			}
+		}
+	}
+
+	if len(cfg.preflightValidators) > 0 {
+		for _, v := range cfg.preflightValidators {
+			for _, err := range v.ValidateDocument(doc) {
+				if cfg.warningCollector != nil {
+					cfg.warningCollector(err.Error())
+				}
+			}
+			for href, asset := range doc.Assets {
+				for _, err := range v.ValidateAsset(href, asset) {
+					if cfg.warningCollector != nil {
+						cfg.warningCollector(err.Error())
+					}
+				}
 			}
 		}
 	}

--- a/encode_example_test.go
+++ b/encode_example_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package epub_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/publira/epub"
+	"github.com/publira/epub/profile/kadokawa"
+	"github.com/publira/epub/profile/kindle"
+)
+
+func ExampleEncode_preflightWithProfile() {
+	doc := &epub.Document{
+		Metadata:  epub.Metadata{Title: "My Book"},
+		Direction: "rtl",
+		Layout:    epub.LayoutPrePaginated,
+		Assets: map[string]*epub.Asset{
+			"item/image/p-001.jpg": {
+				ID:       "p-001",
+				MimeType: "image/jpeg",
+				Size:     100,
+				Open: func() (io.ReadCloser, error) {
+					return io.NopCloser(strings.NewReader("fake")), nil
+				},
+			},
+		},
+		Pages: []*epub.Page{{Order: 0, AssetID: "p-001", Spread: "right"}},
+	}
+
+	var warnings []string
+	var out bytes.Buffer
+	err := epub.Encode(&out, doc,
+		epub.WithValidator(kadokawa.New()),
+		epub.WithEncodeWarningCollector(func(w string) { warnings = append(warnings, w) }),
+	)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+
+	fmt.Println(len(warnings), "warning(s)")
+	// Output:
+	// 0 warning(s)
+}
+
+func ExampleEncode_preflightWithMultipleProfiles() {
+	doc := &epub.Document{
+		Metadata:  epub.Metadata{Title: "Multi-Profile Book"},
+		Direction: "rtl",
+		Layout:    epub.LayoutPrePaginated,
+		Assets: map[string]*epub.Asset{
+			"item/image/p-001.jpg": {
+				ID:       "p-001",
+				MimeType: "image/jpeg",
+				Size:     100,
+				Open: func() (io.ReadCloser, error) {
+					return io.NopCloser(strings.NewReader("fake")), nil
+				},
+			},
+		},
+		Pages: []*epub.Page{{Order: 0, AssetID: "p-001", Spread: "right"}},
+	}
+
+	var warnings []string
+	var out bytes.Buffer
+	err := epub.Encode(&out, doc,
+		epub.WithValidator(kadokawa.New(), kindle.New()),
+		epub.WithEncodeWarningCollector(func(w string) { warnings = append(warnings, w) }),
+	)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+
+	fmt.Println(len(warnings), "warning(s)")
+	// Output:
+	// 0 warning(s)
+}

--- a/epub_example_test.go
+++ b/epub_example_test.go
@@ -3,9 +3,11 @@
 package epub
 
 import (
+	"archive/zip"
 	"bytes"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"strings"
 )
 
@@ -52,4 +54,149 @@ func ExampleDocument_AddPageWithAsset() {
 	// item/xhtml/p-001.xhtml
 	// image/png
 	// 1 2
+}
+
+// customValidator is a minimal Validator that rejects images exceeding a
+// configurable byte-size limit.
+type customValidator struct {
+	maxImageSize uint64
+}
+
+func (v *customValidator) ValidateDocument(_ *Document) []error { return nil }
+
+func (v *customValidator) ValidateAsset(href string, asset *Asset) []error {
+	if asset == nil {
+		return nil
+	}
+	if strings.HasPrefix(asset.MimeType, "image/") && asset.Size > v.maxImageSize {
+		return []error{&ValidationWarningError{
+			Message: fmt.Sprintf("image %q is too large: %d bytes", href, asset.Size),
+		}}
+	}
+	return nil
+}
+
+func ExampleDecode_withCustomValidator() {
+	epubData := exampleMinimalEPUB()
+
+	v := &customValidator{maxImageSize: 1024 * 1024} // 1 MB
+
+	doc, err := Decode(
+		bytes.NewReader(epubData), int64(len(epubData)),
+		WithValidator(v),
+	)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+
+	fmt.Println(doc.Metadata.Title)
+	fmt.Println(len(doc.Warnings), "warning(s)")
+	// Output:
+	// Test Book
+	// 0 warning(s)
+}
+
+func ExampleDecode_withMultipleValidators() {
+	epubData := exampleMinimalEPUB()
+
+	v1 := &customValidator{maxImageSize: 1024 * 1024} // 1 MB
+	v2 := &customValidator{maxImageSize: 512 * 1024}  // 512 KB
+
+	doc, err := Decode(
+		bytes.NewReader(epubData), int64(len(epubData)),
+		WithValidator(v1, v2),
+	)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+
+	fmt.Println(doc.Metadata.Title)
+	fmt.Println(len(doc.Warnings), "warning(s)")
+	// Output:
+	// Test Book
+	// 0 warning(s)
+}
+
+func ExampleEncode_withPreflightValidator() {
+	doc := &Document{
+		Metadata:  Metadata{Title: "Demo"},
+		Direction: "rtl",
+		Layout:    LayoutPrePaginated,
+		Assets: map[string]*Asset{
+			"item/image/p-001.jpg": {
+				ID:       "p-001",
+				MimeType: "image/jpeg",
+				Size:     100,
+				Open: func() (io.ReadCloser, error) {
+					return io.NopCloser(strings.NewReader("fake")), nil
+				},
+			},
+		},
+		Pages: []*Page{{Order: 0, AssetID: "p-001", Spread: "right"}},
+	}
+
+	v := &customValidator{maxImageSize: 50} // intentionally small
+
+	var warnings []string
+	var out bytes.Buffer
+	err := Encode(&out, doc,
+		WithValidator(v),
+		WithEncodeWarningCollector(func(w string) { warnings = append(warnings, w) }),
+	)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+
+	fmt.Println(len(warnings), "warning(s)")
+	for _, w := range warnings {
+		fmt.Println(w)
+	}
+	// Output:
+	// 1 warning(s)
+	// image "item/image/p-001.jpg" is too large: 100 bytes
+}
+
+func exampleMinimalEPUB() []byte {
+	container := `<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="item/standard.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>`
+
+	opf := `<?xml version="1.0" encoding="UTF-8"?>
+<package version="3.0" xmlns="http://www.idpf.org/2007/opf">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Test Book</dc:title>
+  </metadata>
+  <manifest>
+    <item id="xhtml-1" href="xhtml/p-001.xhtml" media-type="application/xhtml+xml"/>
+    <item id="p-001" href="image/p-001.jpg" media-type="image/jpeg"/>
+  </manifest>
+  <spine page-progression-direction="rtl">
+    <itemref idref="xhtml-1" properties="page-spread-right"/>
+  </spine>
+</package>`
+
+	xhtml := `<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><head><title>p1</title></head><body><p>hello</p></body></html>`
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, _ := zw.CreateHeader(&zip.FileHeader{Name: "mimetype", Method: zip.Store})
+	_, _ = w.Write([]byte(mimeTypeValue))
+	for _, f := range []struct{ name, body string }{
+		{"META-INF/container.xml", container},
+		{"item/standard.opf", opf},
+		{"item/xhtml/p-001.xhtml", xhtml},
+		{"item/image/p-001.jpg", "fake-jpeg"},
+	} {
+		w, _ := zw.Create(f.name)
+		_, _ = w.Write([]byte(f.body))
+	}
+	_ = zw.Close()
+	return buf.Bytes()
 }

--- a/option.go
+++ b/option.go
@@ -3,59 +3,139 @@
 package epub
 
 // ComplianceLevel controls strictness of EPUB validations.
+//
+// Deprecated: Use [WithValidator] with profile sub-packages instead.
 type ComplianceLevel int
 
 const (
 	// LevelFlexible allows broader structures as long as package integrity is valid.
+	//
+	// Deprecated: Use [WithValidator] with profile sub-packages instead.
 	LevelFlexible ComplianceLevel = iota
 	// LevelEBPAJ enforces EBPAJ-oriented naming and directory conventions.
+	//
+	// Deprecated: Use [WithValidator] with [github.com/publira/epub/profile/ebpaj] instead.
 	LevelEBPAJ
 	// LevelKADOKAWA enforces KADOKAWA-oriented naming and directory conventions.
+	//
+	// Deprecated: Use [WithValidator] with [github.com/publira/epub/profile/kadokawa] instead.
 	LevelKADOKAWA
 	// LevelKindle enforces Amazon Kindle (KDP) publishing guidelines.
+	//
+	// Deprecated: Use [WithValidator] with [github.com/publira/epub/profile/kindle] instead.
 	LevelKindle
 )
 
 // decodeConfig stores Decode options.
 type decodeConfig struct {
 	compliance               ComplianceLevel
+	validators               []Validator
 	maxAssetCount            int
 	maxTotalUncompressedSize int64
 	maxIndividualAssetSize   int64
 }
 
-// DecodeOption mutates decode behavior.
-type DecodeOption func(*decodeConfig)
+// DecodeOption configures Decode behavior.
+type DecodeOption interface {
+	applyDecode(*decodeConfig)
+}
+
+// decodeOptionFunc wraps a function as a [DecodeOption].
+type decodeOptionFunc func(*decodeConfig)
+
+func (f decodeOptionFunc) applyDecode(c *decodeConfig) { f(c) }
+
+// EncodeOption configures Encode behavior.
+type EncodeOption interface {
+	applyEncode(*encodeConfig)
+}
+
+// encodeOptionFunc wraps a function as an [EncodeOption].
+type encodeOptionFunc func(*encodeConfig)
+
+func (f encodeOptionFunc) applyEncode(c *encodeConfig) { f(c) }
+
+// Option applies to both Decode and Encode.
+type Option interface {
+	DecodeOption
+	EncodeOption
+}
+
+// optionFunc implements [Option].
+type optionFunc struct {
+	decode func(*decodeConfig)
+	encode func(*encodeConfig)
+}
+
+func (f optionFunc) applyDecode(c *decodeConfig) {
+	if f.decode != nil {
+		f.decode(c)
+	}
+}
+
+func (f optionFunc) applyEncode(c *encodeConfig) {
+	if f.encode != nil {
+		f.encode(c)
+	}
+}
 
 // WithCompliance configures strictness level used by Decode.
+//
+// Deprecated: Use [WithValidator] with profile sub-packages instead.
 func WithCompliance(level ComplianceLevel) DecodeOption {
-	return func(cfg *decodeConfig) {
+	return decodeOptionFunc(func(cfg *decodeConfig) {
 		cfg.compliance = level
+	})
+}
+
+// WithValidator registers one or more [Validator] implementations.
+//
+// When passed to [Decode], validators are run after the [Document] is fully
+// constructed. Errors implementing [*ValidationWarningError] are collected
+// into [Document.Warnings]; all other errors cause Decode to fail.
+//
+// When passed to [Encode], validators are executed as preflight checks before
+// writing the EPUB ZIP. All errors (including non-warning) are delivered as
+// warnings through the collector registered via [WithEncodeWarningCollector].
+//
+// Example:
+//
+//	doc, err := epub.Decode(f, size,
+//	    epub.WithValidator(kadokawa.New(), kindle.New()),
+//	)
+func WithValidator(validators ...Validator) Option {
+	return optionFunc{
+		decode: func(c *decodeConfig) {
+			c.validators = append(c.validators, validators...)
+		},
+		encode: func(c *encodeConfig) {
+			c.preflightValidators = append(c.preflightValidators, validators...)
+		},
 	}
 }
 
 // WithMaxAssetCount limits the number of ZIP entries accepted during Decode.
 // A value <= 0 disables this limit.
 func WithMaxAssetCount(max int) DecodeOption {
-	return func(cfg *decodeConfig) {
+	return decodeOptionFunc(func(cfg *decodeConfig) {
 		cfg.maxAssetCount = max
-	}
+	})
 }
 
 // WithMaxTotalUncompressedSize limits the sum of all ZIP entry uncompressed sizes accepted during Decode.
 // A value <= 0 disables this limit.
 func WithMaxTotalUncompressedSize(max int64) DecodeOption {
-	return func(cfg *decodeConfig) {
+	return decodeOptionFunc(func(cfg *decodeConfig) {
 		cfg.maxTotalUncompressedSize = max
-	}
+	})
 }
 
 // WithMaxIndividualAssetSize limits each ZIP entry uncompressed size accepted during Decode.
 // A value <= 0 disables this limit.
 func WithMaxIndividualAssetSize(max int64) DecodeOption {
-	return func(cfg *decodeConfig) {
+	return decodeOptionFunc(func(cfg *decodeConfig) {
 		cfg.maxIndividualAssetSize = max
-	}
+	})
 }
 
 func defaultDecodeConfig() decodeConfig {

--- a/profile/ebpaj/ebpaj.go
+++ b/profile/ebpaj/ebpaj.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package ebpaj provides an [epub.Validator] that enforces EBPAJ
+// (Electronic Book Publishers Association of Japan) guidelines.
+//
+// Checks performed:
+//   - Directory layout: assets must reside under item/xhtml/, item/image/,
+//     item/style/, or directly under item/.
+//   - Image naming: must match item/image/p-NNN.(jpg|png).
+//   - Image file size: must be under 4 MB.
+//   - Image pixel count: must be under 4,000,000.
+//   - Progressive JPEG: not allowed.
+//   - XHTML file size: warns when exceeding 256 KB.
+package ebpaj
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+	"io"
+	"path"
+	"regexp"
+	"strings"
+
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
+
+	"github.com/publira/epub"
+
+	_ "golang.org/x/image/webp"
+)
+
+var imageNamePattern = regexp.MustCompile(`^item/image/p-[0-9]{3,4}\.(jpg|png)$`)
+
+const (
+	maxImagePixelCount = 4000000
+	maxImageFileSize   = 4 * 1024 * 1024 // 4 MB
+	maxXHTMLFileSize   = 256 * 1024      // 256 KB
+)
+
+type validator struct{}
+
+// New returns a Validator that enforces EBPAJ guidelines.
+func New() epub.Validator { return &validator{} }
+
+func (v *validator) ValidateDocument(_ *epub.Document) []error { return nil }
+
+func (v *validator) ValidateAsset(href string, asset *epub.Asset) []error {
+	if asset == nil {
+		return nil
+	}
+	var errs []error
+
+	// Directory layout check.
+	if err := validateDirectoryRule(href); err != nil {
+		errs = append(errs, err)
+	}
+
+	mt := strings.ToLower(strings.TrimSpace(asset.MimeType))
+
+	if strings.HasPrefix(mt, "image/") {
+		// Image naming.
+		if !imageNamePattern.MatchString(href) {
+			errs = append(errs, fmt.Errorf("image path %q must follow item/image/p-000.(jpg|png) format", href))
+		}
+
+		// Image file size.
+		if asset.Size > uint64(maxImageFileSize) {
+			errs = append(errs, &epub.ImageFileSizeTooLargeError{
+				Href:   href,
+				Limit:  maxImageFileSize,
+				Actual: int64(asset.Size),
+			})
+		}
+
+		// Pixel count and progressive JPEG.
+		if asset.Open != nil {
+			errs = append(errs, validateImageSpecs(href, asset)...)
+		}
+	} else if strings.Contains(mt, "xhtml") {
+		if asset.Size > uint64(maxXHTMLFileSize) {
+			errs = append(errs, &epub.ValidationWarningError{
+				Message: fmt.Sprintf("XHTML file %s exceeds 256KB (%s), may cause RS performance issues",
+					href, formatBytes(int64(asset.Size))),
+			})
+		}
+	}
+
+	return errs
+}
+
+func validateDirectoryRule(href string) error {
+	dir := path.Dir(href)
+	if dir == "." {
+		return fmt.Errorf("asset path %q must be under item/xhtml, item/image, or item/style", href)
+	}
+	if dir == "item" {
+		return nil
+	}
+	if strings.HasPrefix(href, "item/xhtml/") || strings.HasPrefix(href, "item/image/") || strings.HasPrefix(href, "item/style/") {
+		return nil
+	}
+	return fmt.Errorf("asset path %q must be under item/xhtml, item/image, or item/style", href)
+}
+
+func validateImageSpecs(href string, asset *epub.Asset) []error {
+	rc, err := asset.Open()
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = rc.Close() }()
+
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		return nil
+	}
+
+	var errs []error
+
+	cfg, format, err := image.DecodeConfig(bytes.NewReader(data))
+	if err != nil {
+		return nil
+	}
+
+	pixelCount := int64(cfg.Width) * int64(cfg.Height)
+	if pixelCount > maxImagePixelCount {
+		errs = append(errs, &epub.ImagePixelCountExceededError{
+			Href:   href,
+			Limit:  maxImagePixelCount,
+			Actual: pixelCount,
+		})
+	}
+
+	if format == "jpeg" && isProgressiveJPEG(data) {
+		errs = append(errs, &epub.ProgressiveJPEGNotAllowedError{Href: href})
+	}
+
+	return errs
+}
+
+func isProgressiveJPEG(data []byte) bool {
+	for i := 0; i < len(data)-1; i++ {
+		if data[i] == 0xFF && data[i+1] == 0xC2 {
+			return true
+		}
+	}
+	return false
+}
+
+func formatBytes(b int64) string {
+	if b < 1024 {
+		return fmt.Sprintf("%dB", b)
+	} else if b < 1024*1024 {
+		return fmt.Sprintf("%.1fKB", float64(b)/1024)
+	}
+	return fmt.Sprintf("%.1fMB", float64(b)/(1024*1024))
+}

--- a/profile/ebpaj/ebpaj_test.go
+++ b/profile/ebpaj/ebpaj_test.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ebpaj_test
+
+import (
+	"bytes"
+	"errors"
+	"image"
+	"image/color"
+	"image/png"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/publira/epub"
+	"github.com/publira/epub/profile/ebpaj"
+)
+
+func testPNGBytes() []byte {
+	img := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	img.Set(0, 0, color.White)
+	var buf bytes.Buffer
+	_ = png.Encode(&buf, img)
+	return buf.Bytes()
+}
+
+func TestValidateAsset_DirectoryLayoutError(t *testing.T) {
+	v := ebpaj.New()
+	asset := &epub.Asset{ID: "x", MimeType: "image/jpeg", Size: 100}
+	errs := v.ValidateAsset("bad/path.jpg", asset)
+	if len(errs) == 0 {
+		t.Fatal("expected directory-layout error")
+	}
+	found := false
+	for _, err := range errs {
+		if strings.Contains(err.Error(), "item/xhtml") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected directory layout error, got: %v", errs)
+	}
+}
+
+func TestValidateAsset_ImageNamingError(t *testing.T) {
+	v := ebpaj.New()
+	pngData := testPNGBytes()
+	asset := &epub.Asset{
+		ID: "x", MimeType: "image/png", Size: uint64(len(pngData)),
+		Open: func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(pngData)), nil
+		},
+	}
+	errs := v.ValidateAsset("item/image/BADNAME.png", asset)
+	found := false
+	for _, err := range errs {
+		if strings.Contains(err.Error(), "item/image/p-000") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected naming error, got: %v", errs)
+	}
+}
+
+func TestValidateAsset_ValidImage(t *testing.T) {
+	v := ebpaj.New()
+	pngData := testPNGBytes()
+	asset := &epub.Asset{
+		ID: "p-001", MimeType: "image/png", Size: uint64(len(pngData)),
+		Open: func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(pngData)), nil
+		},
+	}
+	errs := v.ValidateAsset("item/image/p-001.png", asset)
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors for valid image, got: %v", errs)
+	}
+}
+
+func TestValidateAsset_ImageFileSizeError(t *testing.T) {
+	v := ebpaj.New()
+	asset := &epub.Asset{
+		ID: "p-001", MimeType: "image/jpeg", Size: 5 * 1024 * 1024,
+		Open: func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader([]byte("fake"))), nil
+		},
+	}
+	errs := v.ValidateAsset("item/image/p-001.jpg", asset)
+	found := false
+	for _, err := range errs {
+		var fsErr *epub.ImageFileSizeTooLargeError
+		if errors.As(err, &fsErr) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected ImageFileSizeTooLargeError, got: %v", errs)
+	}
+}
+
+func TestValidateAsset_XHTMLSizeWarning(t *testing.T) {
+	v := ebpaj.New()
+	asset := &epub.Asset{
+		ID: "x-001", MimeType: "application/xhtml+xml", Size: 300 * 1024,
+	}
+	errs := v.ValidateAsset("item/xhtml/page.xhtml", asset)
+	found := false
+	for _, err := range errs {
+		var w *epub.ValidationWarningError
+		if errors.As(err, &w) && strings.Contains(w.Message, "XHTML") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected XHTML warning, got: %v", errs)
+	}
+}
+
+func TestValidateDocument_ReturnsNil(t *testing.T) {
+	v := ebpaj.New()
+	errs := v.ValidateDocument(&epub.Document{})
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got: %v", errs)
+	}
+}
+
+func TestValidateAsset_NilAsset(t *testing.T) {
+	v := ebpaj.New()
+	errs := v.ValidateAsset("item/image/p-001.png", nil)
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors for nil asset, got: %v", errs)
+	}
+}

--- a/profile/kadokawa/kadokawa.go
+++ b/profile/kadokawa/kadokawa.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package kadokawa provides an [epub.Validator] that enforces KADOKAWA
+// digital-publishing guidelines.
+//
+// Checks performed:
+//   - Directory layout: assets must reside under item/xhtml/, item/image/,
+//     item/style/, or directly under item/.
+//   - Image naming: must match KADOKAWA spec §2 (ASCII lowercase alphanumeric,
+//     hyphen, underscore; starts with a letter).
+//   - Image file size: must be under 4 MB.
+//   - Image pixel count: must be under 4,000,000.
+//   - Progressive JPEG: not allowed.
+//   - XHTML file size: warns when exceeding 256 KB.
+package kadokawa
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+	"io"
+	"path"
+	"regexp"
+	"strings"
+
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
+
+	"github.com/publira/epub"
+
+	_ "golang.org/x/image/webp"
+)
+
+var imageNamePattern = regexp.MustCompile(`^item/image/[a-z][a-z0-9_-]*\.(jpg|jpeg|png|gif)$`)
+
+const (
+	maxImagePixelCount = 4000000
+	maxImageFileSize   = 4 * 1024 * 1024 // 4 MB
+	maxXHTMLFileSize   = 256 * 1024      // 256 KB
+)
+
+type validator struct{}
+
+// New returns a Validator that enforces KADOKAWA guidelines.
+func New() epub.Validator { return &validator{} }
+
+func (v *validator) ValidateDocument(_ *epub.Document) []error { return nil }
+
+func (v *validator) ValidateAsset(href string, asset *epub.Asset) []error {
+	if asset == nil {
+		return nil
+	}
+	var errs []error
+
+	// Directory layout check.
+	if err := validateDirectoryRule(href); err != nil {
+		errs = append(errs, err)
+	}
+
+	mt := strings.ToLower(strings.TrimSpace(asset.MimeType))
+
+	if strings.HasPrefix(mt, "image/") {
+		// Image naming.
+		if !imageNamePattern.MatchString(href) {
+			errs = append(errs, fmt.Errorf("image path %q does not match KADOKAWA naming rules", href))
+		}
+
+		// Image file size.
+		if asset.Size > uint64(maxImageFileSize) {
+			errs = append(errs, &epub.ImageFileSizeTooLargeError{
+				Href:   href,
+				Limit:  maxImageFileSize,
+				Actual: int64(asset.Size),
+			})
+		}
+
+		// Pixel count and progressive JPEG.
+		if asset.Open != nil {
+			errs = append(errs, validateImageSpecs(href, asset)...)
+		}
+	} else if strings.Contains(mt, "xhtml") {
+		if asset.Size > uint64(maxXHTMLFileSize) {
+			errs = append(errs, &epub.ValidationWarningError{
+				Message: fmt.Sprintf("XHTML file %s exceeds 256KB (%s), may cause RS performance issues",
+					href, formatBytes(int64(asset.Size))),
+			})
+		}
+	}
+
+	return errs
+}
+
+func validateDirectoryRule(href string) error {
+	dir := path.Dir(href)
+	if dir == "." {
+		return fmt.Errorf("asset path %q must be under item/xhtml, item/image, or item/style", href)
+	}
+	if dir == "item" {
+		return nil
+	}
+	if strings.HasPrefix(href, "item/xhtml/") || strings.HasPrefix(href, "item/image/") || strings.HasPrefix(href, "item/style/") {
+		return nil
+	}
+	return fmt.Errorf("asset path %q must be under item/xhtml, item/image, or item/style", href)
+}
+
+func validateImageSpecs(href string, asset *epub.Asset) []error {
+	rc, err := asset.Open()
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = rc.Close() }()
+
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		return nil
+	}
+
+	var errs []error
+
+	cfg, format, err := image.DecodeConfig(bytes.NewReader(data))
+	if err != nil {
+		return nil
+	}
+
+	pixelCount := int64(cfg.Width) * int64(cfg.Height)
+	if pixelCount > maxImagePixelCount {
+		errs = append(errs, &epub.ImagePixelCountExceededError{
+			Href:   href,
+			Limit:  maxImagePixelCount,
+			Actual: pixelCount,
+		})
+	}
+
+	if format == "jpeg" && isProgressiveJPEG(data) {
+		errs = append(errs, &epub.ProgressiveJPEGNotAllowedError{Href: href})
+	}
+
+	return errs
+}
+
+func isProgressiveJPEG(data []byte) bool {
+	for i := 0; i < len(data)-1; i++ {
+		if data[i] == 0xFF && data[i+1] == 0xC2 {
+			return true
+		}
+	}
+	return false
+}
+
+func formatBytes(b int64) string {
+	if b < 1024 {
+		return fmt.Sprintf("%dB", b)
+	} else if b < 1024*1024 {
+		return fmt.Sprintf("%.1fKB", float64(b)/1024)
+	}
+	return fmt.Sprintf("%.1fMB", float64(b)/(1024*1024))
+}

--- a/profile/kadokawa/kadokawa_test.go
+++ b/profile/kadokawa/kadokawa_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kadokawa_test
+
+import (
+	"bytes"
+	"errors"
+	"image"
+	"image/color"
+	"image/png"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/publira/epub"
+	"github.com/publira/epub/profile/kadokawa"
+)
+
+func testPNGBytes() []byte {
+	img := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	img.Set(0, 0, color.White)
+	var buf bytes.Buffer
+	_ = png.Encode(&buf, img)
+	return buf.Bytes()
+}
+
+func TestValidateAsset_DirectoryLayoutError(t *testing.T) {
+	v := kadokawa.New()
+	asset := &epub.Asset{ID: "x", MimeType: "image/jpeg", Size: 100}
+	errs := v.ValidateAsset("bad/path.jpg", asset)
+	if len(errs) == 0 {
+		t.Fatal("expected directory-layout error")
+	}
+}
+
+func TestValidateAsset_ImageNamingError(t *testing.T) {
+	v := kadokawa.New()
+	pngData := testPNGBytes()
+	asset := &epub.Asset{
+		ID: "x", MimeType: "image/png", Size: uint64(len(pngData)),
+		Open: func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(pngData)), nil
+		},
+	}
+	errs := v.ValidateAsset("item/image/BADNAME.png", asset)
+	found := false
+	for _, err := range errs {
+		if strings.Contains(err.Error(), "KADOKAWA") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected naming error, got: %v", errs)
+	}
+}
+
+func TestValidateAsset_ValidImage(t *testing.T) {
+	v := kadokawa.New()
+	pngData := testPNGBytes()
+	asset := &epub.Asset{
+		ID: "p-001", MimeType: "image/png", Size: uint64(len(pngData)),
+		Open: func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(pngData)), nil
+		},
+	}
+	errs := v.ValidateAsset("item/image/p-001.png", asset)
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors for valid image, got: %v", errs)
+	}
+}
+
+func TestValidateAsset_XHTMLSizeWarning(t *testing.T) {
+	v := kadokawa.New()
+	asset := &epub.Asset{
+		ID: "x-001", MimeType: "application/xhtml+xml", Size: 300 * 1024,
+	}
+	errs := v.ValidateAsset("item/xhtml/page.xhtml", asset)
+	found := false
+	for _, err := range errs {
+		var w *epub.ValidationWarningError
+		if errors.As(err, &w) && strings.Contains(w.Message, "XHTML") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected XHTML warning, got: %v", errs)
+	}
+}
+
+func TestValidateDocument_ReturnsNil(t *testing.T) {
+	v := kadokawa.New()
+	errs := v.ValidateDocument(&epub.Document{})
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got: %v", errs)
+	}
+}

--- a/profile/kindle/kindle.go
+++ b/profile/kindle/kindle.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package kindle provides an [epub.Validator] that enforces Amazon Kindle
+// (KDP) publishing guidelines.
+//
+// All violations are returned as [epub.ValidationWarningError] so they appear as
+// non-fatal warnings during Decode.
+//
+// Checks performed:
+//   - Image file size: warns when exceeding 5 MB.
+//   - Progressive JPEG: warns (not supported by Kindle).
+//   - XHTML file size: warns when exceeding 256 KB.
+package kindle
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+	"io"
+	"strings"
+
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
+
+	"github.com/publira/epub"
+
+	_ "golang.org/x/image/webp"
+)
+
+const (
+	maxImageFileSizeKindle = 5 * 1024 * 1024 // 5 MB
+	maxXHTMLFileSize       = 256 * 1024      // 256 KB
+)
+
+type validator struct{}
+
+// New returns a Validator that enforces Kindle (KDP) guidelines.
+func New() epub.Validator { return &validator{} }
+
+func (v *validator) ValidateDocument(_ *epub.Document) []error { return nil }
+
+func (v *validator) ValidateAsset(href string, asset *epub.Asset) []error {
+	if asset == nil {
+		return nil
+	}
+	var errs []error
+
+	mt := strings.ToLower(strings.TrimSpace(asset.MimeType))
+
+	if strings.HasPrefix(mt, "image/") {
+		// Image file size (5 MB Kindle limit).
+		if asset.Size > uint64(maxImageFileSizeKindle) {
+			errs = append(errs, &epub.ValidationWarningError{
+				Message: fmt.Sprintf("image %q file size %s exceeds Kindle %s limit",
+					href, formatBytes(int64(asset.Size)), formatBytes(maxImageFileSizeKindle)),
+			})
+		}
+
+		// Progressive JPEG.
+		if asset.Open != nil {
+			errs = append(errs, validateImageSpecs(href, asset)...)
+		}
+	} else if strings.Contains(mt, "xhtml") {
+		if asset.Size > uint64(maxXHTMLFileSize) {
+			errs = append(errs, &epub.ValidationWarningError{
+				Message: fmt.Sprintf("XHTML file %s exceeds 256KB (%s), may cause RS performance issues",
+					href, formatBytes(int64(asset.Size))),
+			})
+		}
+	}
+
+	return errs
+}
+
+func validateImageSpecs(href string, asset *epub.Asset) []error {
+	rc, err := asset.Open()
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = rc.Close() }()
+
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		return nil
+	}
+
+	_, format, err := image.DecodeConfig(bytes.NewReader(data))
+	if err != nil {
+		return nil
+	}
+
+	if format == "jpeg" && isProgressiveJPEG(data) {
+		return []error{&epub.ValidationWarningError{
+			Message: fmt.Sprintf("image %q is a progressive JPEG, which is not supported by Kindle", href),
+		}}
+	}
+
+	return nil
+}
+
+func isProgressiveJPEG(data []byte) bool {
+	for i := 0; i < len(data)-1; i++ {
+		if data[i] == 0xFF && data[i+1] == 0xC2 {
+			return true
+		}
+	}
+	return false
+}
+
+func formatBytes(b int64) string {
+	if b < 1024 {
+		return fmt.Sprintf("%dB", b)
+	} else if b < 1024*1024 {
+		return fmt.Sprintf("%.1fKB", float64(b)/1024)
+	}
+	return fmt.Sprintf("%.1fMB", float64(b)/(1024*1024))
+}

--- a/profile/kindle/kindle_test.go
+++ b/profile/kindle/kindle_test.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kindle_test
+
+import (
+	"bytes"
+	"errors"
+	"image"
+	"image/color"
+	"image/png"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/publira/epub"
+	"github.com/publira/epub/profile/kindle"
+)
+
+func testPNGBytes() []byte {
+	img := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	img.Set(0, 0, color.White)
+	var buf bytes.Buffer
+	_ = png.Encode(&buf, img)
+	return buf.Bytes()
+}
+
+// testProgressiveJPEGBytes returns minimal bytes that look like a progressive JPEG.
+func testProgressiveJPEGBytes() []byte {
+	return []byte{
+		0xFF, 0xD8, // SOI
+		0xFF, 0xE0, // APP0
+		0x00, 0x10, // length 16
+		0x4A, 0x46, 0x49, 0x46, 0x00, // "JFIF\0"
+		0x01, 0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00,
+		0xFF, 0xC2, // SOF2 (progressive)
+		0x00, 0x0B, 0x08, 0x00, 0x01, 0x00, 0x01, 0x01, 0x01, 0x11, 0x00,
+		0xFF, 0xD9, // EOI
+	}
+}
+
+func TestValidateAsset_ImageFileSizeWarning(t *testing.T) {
+	v := kindle.New()
+	asset := &epub.Asset{
+		ID: "big", MimeType: "image/jpeg", Size: 6 * 1024 * 1024,
+		Open: func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader([]byte("fake"))), nil
+		},
+	}
+	errs := v.ValidateAsset("images/big.jpg", asset)
+	found := false
+	for _, err := range errs {
+		var w *epub.ValidationWarningError
+		if errors.As(err, &w) && strings.Contains(w.Message, "Kindle") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected Kindle file size warning, got: %v", errs)
+	}
+}
+
+func TestValidateAsset_ProgressiveJPEGWarning(t *testing.T) {
+	v := kindle.New()
+	jpegData := testProgressiveJPEGBytes()
+	asset := &epub.Asset{
+		ID: "photo", MimeType: "image/jpeg", Size: uint64(len(jpegData)),
+		Open: func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(jpegData)), nil
+		},
+	}
+	errs := v.ValidateAsset("images/photo.jpg", asset)
+	found := false
+	for _, err := range errs {
+		var w *epub.ValidationWarningError
+		if errors.As(err, &w) && strings.Contains(w.Message, "progressive JPEG") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected progressive JPEG warning, got: %v", errs)
+	}
+}
+
+func TestValidateAsset_ValidSmallImage(t *testing.T) {
+	v := kindle.New()
+	pngData := testPNGBytes()
+	asset := &epub.Asset{
+		ID: "img", MimeType: "image/png", Size: uint64(len(pngData)),
+		Open: func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(pngData)), nil
+		},
+	}
+	errs := v.ValidateAsset("images/small.png", asset)
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors for small valid image, got: %v", errs)
+	}
+}
+
+func TestValidateAsset_NoDirectoryLayoutEnforcement(t *testing.T) {
+	v := kindle.New()
+	pngData := testPNGBytes()
+	asset := &epub.Asset{
+		ID: "img", MimeType: "image/png", Size: uint64(len(pngData)),
+		Open: func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(pngData)), nil
+		},
+	}
+	// Kindle should not enforce directory layout.
+	errs := v.ValidateAsset("custom/path/image.png", asset)
+	if len(errs) != 0 {
+		t.Fatalf("Kindle should not enforce directory layout, got: %v", errs)
+	}
+}
+
+func TestValidateAsset_XHTMLSizeWarning(t *testing.T) {
+	v := kindle.New()
+	asset := &epub.Asset{
+		ID: "x-001", MimeType: "application/xhtml+xml", Size: 300 * 1024,
+	}
+	errs := v.ValidateAsset("content/page.xhtml", asset)
+	found := false
+	for _, err := range errs {
+		var w *epub.ValidationWarningError
+		if errors.As(err, &w) && strings.Contains(w.Message, "XHTML") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected XHTML warning, got: %v", errs)
+	}
+}
+
+func TestValidateDocument_ReturnsNil(t *testing.T) {
+	v := kindle.New()
+	errs := v.ValidateDocument(&epub.Document{})
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got: %v", errs)
+	}
+}

--- a/validator.go
+++ b/validator.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package epub
+
+// Validator validates EPUB document and assets.
+//
+// Implementations reside in profile sub-packages such as
+// [github.com/publira/epub/profile/ebpaj],
+// [github.com/publira/epub/profile/kadokawa], and
+// [github.com/publira/epub/profile/kindle].
+type Validator interface {
+	ValidateDocument(doc *Document) []error
+	ValidateAsset(href string, asset *Asset) []error
+}
+
+// ValidationWarningError represents a non-fatal validation issue.
+// Validators may return *ValidationWarningError to signal the issue should be
+// treated as a warning rather than a fatal error during Decode.
+// During Encode preflight all errors (including non-warning) are treated
+// as warnings.
+type ValidationWarningError struct {
+	Message string
+}
+
+func (w *ValidationWarningError) Error() string { return w.Message }

--- a/validator_example_test.go
+++ b/validator_example_test.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package epub_test
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/publira/epub"
+	"github.com/publira/epub/profile/kadokawa"
+	"github.com/publira/epub/profile/kindle"
+)
+
+func ExampleWithValidator() {
+	epubData := minimalValidEPUB()
+
+	doc, err := epub.Decode(
+		bytes.NewReader(epubData), int64(len(epubData)),
+		epub.WithValidator(kadokawa.New(), kindle.New()),
+	)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+
+	fmt.Println(doc.Metadata.Title)
+	fmt.Println(len(doc.Pages), "page(s)")
+	// Output:
+	// Test Book
+	// 1 page(s)
+}
+
+func ExampleWithValidator_warnings() {
+	epubData := minimalValidEPUB()
+
+	// Kindle validator returns only warnings, never fatal errors.
+	doc, err := epub.Decode(
+		bytes.NewReader(epubData), int64(len(epubData)),
+		epub.WithValidator(kindle.New()),
+	)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+
+	if len(doc.Warnings) == 0 {
+		fmt.Println("no warnings")
+	} else {
+		for _, w := range doc.Warnings {
+			fmt.Println("warning:", w)
+		}
+	}
+	// Output:
+	// no warnings
+}
+
+func ExampleWithValidator_encode() {
+	doc := &epub.Document{
+		Metadata:  epub.Metadata{Title: "Demo"},
+		Direction: "rtl",
+		Layout:    epub.LayoutPrePaginated,
+		Assets: map[string]*epub.Asset{
+			"item/image/p-001.jpg": {
+				ID:       "p-001",
+				MimeType: "image/jpeg",
+				Size:     100,
+				Open: func() (io.ReadCloser, error) {
+					return io.NopCloser(strings.NewReader("fake")), nil
+				},
+			},
+		},
+		Pages: []*epub.Page{{Order: 0, AssetID: "p-001", Spread: "right"}},
+	}
+
+	var warnings []string
+	var out bytes.Buffer
+	err := epub.Encode(&out, doc,
+		epub.WithValidator(kadokawa.New()),
+		epub.WithEncodeWarningCollector(func(w string) { warnings = append(warnings, w) }),
+	)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+
+	fmt.Println(len(warnings), "warning(s)")
+	// Output:
+	// 0 warning(s)
+}
+
+// minimalValidEPUB builds a small in-memory EPUB that passes KADOKAWA validation.
+func minimalValidEPUB() []byte {
+	container := `<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="item/standard.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>`
+
+	opf := `<?xml version="1.0" encoding="UTF-8"?>
+<package version="3.0" xmlns="http://www.idpf.org/2007/opf">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Test Book</dc:title>
+  </metadata>
+  <manifest>
+    <item id="xhtml-1" href="xhtml/p-001.xhtml" media-type="application/xhtml+xml"/>
+    <item id="p-001" href="image/p-001.jpg" media-type="image/jpeg"/>
+  </manifest>
+  <spine page-progression-direction="rtl">
+    <itemref idref="xhtml-1" properties="page-spread-right"/>
+  </spine>
+</package>`
+
+	xhtml := `<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><head><title>p1</title></head><body><p>hello</p></body></html>`
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	w, _ := zw.CreateHeader(&zip.FileHeader{Name: "mimetype", Method: zip.Store})
+	_, _ = w.Write([]byte("application/epub+zip"))
+
+	for _, f := range []struct {
+		name, body string
+	}{
+		{"META-INF/container.xml", container},
+		{"item/standard.opf", opf},
+		{"item/xhtml/p-001.xhtml", xhtml},
+		{"item/image/p-001.jpg", "fake-jpeg"},
+	} {
+		w, _ := zw.Create(f.name)
+		_, _ = w.Write([]byte(f.body))
+	}
+	_ = zw.Close()
+	return buf.Bytes()
+}


### PR DESCRIPTION
## Summary

Introduce a pluggable `Validator` interface and extract vendor-specific validation rules into independent profile sub-packages.
A unified `Option` interface allows `WithValidator` to work seamlessly with both `Decode` and `Encode`.

Closes #41

## New Public API

- `Validator` interface with `ValidateDocument`/`ValidateAsset` methods
- `ValidationWarningError` type for non-fatal issues
- `Option` interface that applies to both `Decode` and `Encode`
- `WithValidator(...Validator)` returns `Option` (works with both `Decode` and `Encode`)

## Option Architecture

`DecodeOption` and `EncodeOption` are now interfaces instead of function types.
`Option` embeds both, so a single `WithValidator(...)` call can be passed to either `Decode` or `Encode`:

```go
// Works with Decode
doc, err := epub.Decode(f, size, epub.WithValidator(kadokawa.New()))

// Same option works with Encode
err = epub.Encode(w, doc,
    epub.WithValidator(kadokawa.New()),
    epub.WithEncodeWarningCollector(func(w string) { log.Println(w) }),
)
```

## Profile Sub-packages

| Package | Description |
|---------|-------------|
| `profile/ebpaj` | EBPAJ directory layout, naming, image specs |
| `profile/kadokawa` | KADOKAWA directory layout, naming, image specs |
| `profile/kindle` | Kindle image size / progressive JPEG warnings |

## Expected API Usage

```go
import (
    "github.com/publira/epub"
    "github.com/publira/epub/profile/kadokawa"
    "github.com/publira/epub/profile/kindle"
)

doc, err := epub.Decode(file, size,
    epub.WithValidator(kadokawa.New(), kindle.New()),
)
```

## Backward Compatibility

- `ComplianceLevel` and its constants are preserved with `Deprecated` markers
- `WithCompliance` and `WithEncodePreflightCompliance` are preserved with `Deprecated` markers
- `cmd/epub` migrated from `WithCompliance` to `WithValidator`