### PR TITLE
fix: generate valid UUID for fallback dc:identifier

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -11,6 +11,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 const (
@@ -354,7 +356,7 @@ func spreadToProperty(spread string) string {
 func normalizeIdentifier(v string) string {
 	v = strings.TrimSpace(v)
 	if v == "" {
-		return "urn:uuid:generated"
+		return "urn:uuid:" + uuid.NewString()
 	}
 	return v
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -984,3 +984,26 @@ func TestEncode_KindleMetadata_BookTypeMagazine(t *testing.T) {
 		t.Fatalf("book-type should be magazine:\n%s", opf)
 	}
 }
+
+func TestEncode_FallbackIdentifierIsValidUUID(t *testing.T) {
+	doc := &Document{
+		Metadata:  Metadata{Title: "UUID Test"},
+		Direction: "rtl",
+		Layout:    LayoutPrePaginated,
+	}
+	png := testPNGBytes()
+	if _, _, err := doc.AddPageWithAsset(bytes.NewReader(png), int64(len(png)), "right"); err != nil {
+		t.Fatalf("AddPageWithAsset failed: %v", err)
+	}
+
+	var out bytes.Buffer
+	if err := Encode(&out, doc); err != nil {
+		t.Fatalf("Encode failed: %v", err)
+	}
+
+	opfContent := readZipEntry(t, out.Bytes(), "item/standard.opf")
+	uuidPattern := regexp.MustCompile(`<dc:identifier id="pub-id">urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}</dc:identifier>`)
+	if !uuidPattern.MatchString(opfContent) {
+		t.Fatalf("fallback identifier is not a valid UUID format:\n%s", opfContent)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/publira/epub
 go 1.25.0
 
 require golang.org/x/image v0.38.0
+
+require github.com/google/uuid v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 golang.org/x/image v0.38.0 h1:5l+q+Y9JDC7mBOMjo4/aPhMDcxEptsX+Tt3GgRQRPuE=
 golang.org/x/image v0.38.0/go.mod h1:/3f6vaXC+6CEanU4KJxbcUZyEePbyKbaLoDOe4ehFYY=


### PR DESCRIPTION
## Summary

Use `github.com/google/uuid` to produce a proper RFC 4122 UUID v4 instead of the hardcoded `"urn:uuid:generated"` string. This resolves the EPUBCheck warning `OPF-085`.

## Changes

- `encode.go`: Import `github.com/google/uuid` and call `uuid.NewString()` in `normalizeIdentifier` when no identifier is provided
- `encode_test.go`: Add `TestEncode_FallbackIdentifierIsValidUUID` to verify the generated identifier matches the UUID format
- `go.mod` / `go.sum`: Add `github.com/google/uuid` dependency

Fixes #45