### PR TITLE
fix: use rendition: prefix for page-spread-center

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -347,7 +347,7 @@ func spreadToProperty(spread string) string {
 	case "right":
 		return "page-spread-right"
 	case "center":
-		return "page-spread-center"
+		return "rendition:page-spread-center"
 	default:
 		return ""
 	}


### PR DESCRIPTION
## Summary

Use `rendition:` prefix for `page-spread-center` property in the OPF spine itemref to comply with the EPUB 3 specification.

## Problem

EPUBCheck reports a fatal error when encountering `page-spread-center` without the `rendition:` namespace prefix:

```
ERROR(OPF-027): Undefined property: "page-spread-center".
```

In the EPUB 3 specification, `page-spread-left` and `page-spread-right` are base properties, but `page-spread-center` is defined in the Multiple-Rendition extension and requires the `rendition:` prefix.

## Changes

- Update `spreadToProperty()` in `encode.go` to return `rendition:page-spread-center` instead of `page-spread-center`.

Fixes #46