### PR TITLE
chore: update renovate configuration schema and extends

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,5 +1,4 @@
 {
-  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  extends: ['config:best-practices'],
-  postUpdateOptions: ['gomodTidy'],
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["github>publira/.github//renovate.json5"],
 }


### PR DESCRIPTION
This pull request updates the Renovate configuration to extend from a shared configuration in the `publira` GitHub organization, instead of using the local best-practices configuration. This centralizes dependency management settings and ensures consistency across projects.

Renovate configuration update:

* Changed the `extends` property in `.github/renovate.json5` to inherit settings from `github>publira/.github//renovate.json5`, replacing the previous `config:best-practices` and removing the `postUpdateOptions` customization.