### PR TITLE
feat: support page navigation titles

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -446,6 +446,15 @@ func resolveCoverPageHref(doc *Document, coverAssetID string) string {
 	return ""
 }
 
+func pageNavigationTitle(page *Page, ordinal int) string {
+	if page != nil {
+		if title := strings.TrimSpace(page.Title); title != "" {
+			return title
+		}
+	}
+	return fmt.Sprintf("Page %d", ordinal)
+}
+
 func buildNavigationDocument(doc *Document, coverAssetID string) (string, error) {
 	tocItems := make([]navListItem, 0, len(doc.Pages))
 	for i, pg := range doc.Pages {
@@ -465,7 +474,7 @@ func buildNavigationDocument(doc *Document, coverAssetID string) (string, error)
 			href = "#"
 		}
 		tocItems = append(tocItems, navListItem{
-			Anchor: navLandmarkAnchor{Href: href, Text: fmt.Sprintf("Page %d", i+1)},
+			Anchor: navLandmarkAnchor{Href: href, Text: pageNavigationTitle(pg, i+1)},
 		})
 	}
 	if len(tocItems) == 0 {
@@ -537,7 +546,7 @@ func buildLegacyNCX(doc *Document, identifier string) (string, error) {
 		navPoints = append(navPoints, ncxNavPoint{
 			ID:        fmt.Sprintf("navPoint-%d", i+1),
 			PlayOrder: i + 1,
-			NavLabel:  ncxNavLabel{Text: fmt.Sprintf("Page %d", i+1)},
+			NavLabel:  ncxNavLabel{Text: pageNavigationTitle(pg, i+1)},
 			Content:   ncxContent{Src: href},
 		})
 	}

--- a/encode_test.go
+++ b/encode_test.go
@@ -159,6 +159,48 @@ func TestEncode_WithLegacyTOC_GeneratesNCXWithMatchingUID(t *testing.T) {
 	}
 }
 
+func TestEncode_UsesPageTitlesInNavigation(t *testing.T) {
+	doc := &Document{
+		Metadata: Metadata{Title: "Navigation titles", Identifier: "titles-1"},
+		Layout:   LayoutReflowable,
+		Pages: []*Page{
+			{Order: 0, AssetID: "chapter-1", Href: "item/xhtml/chapter-1.xhtml", Title: "Chapter & One"},
+			{Order: 1, AssetID: "chapter-2", Href: "item/xhtml/chapter-2.xhtml", Title: "   "},
+		},
+		Assets: map[string]*Asset{
+			"item/xhtml/chapter-1.xhtml": {
+				ID:       "chapter-1",
+				MimeType: "application/xhtml+xml",
+				Open: func() (io.ReadCloser, error) {
+					return io.NopCloser(strings.NewReader("<html/>")), nil
+				},
+			},
+			"item/xhtml/chapter-2.xhtml": {
+				ID:       "chapter-2",
+				MimeType: "application/xhtml+xml",
+				Open: func() (io.ReadCloser, error) {
+					return io.NopCloser(strings.NewReader("<html/>")), nil
+				},
+			},
+		},
+	}
+
+	var out bytes.Buffer
+	if err := Encode(&out, doc, WithLegacyTOC()); err != nil {
+		t.Fatalf("Encode failed: %v", err)
+	}
+
+	for _, name := range []string{"item/nav.xhtml", "item/toc.ncx"} {
+		content := readZipEntry(t, out.Bytes(), name)
+		if !strings.Contains(content, "Chapter &amp; One") {
+			t.Fatalf("%s does not contain escaped page title: %s", name, content)
+		}
+		if !strings.Contains(content, "Page 2") {
+			t.Fatalf("%s does not contain fallback page title: %s", name, content)
+		}
+	}
+}
+
 func TestEncode_Issue4AdvancedMetadata(t *testing.T) {
 	doc := &Document{
 		Metadata: Metadata{

--- a/epub.go
+++ b/epub.go
@@ -447,10 +447,12 @@ type Page struct {
 	Order   int
 	AssetID string
 	Href    string
-	Width   int
-	Height  int
-	Spread  string   // "left", "right", "center", "none".
-	Type    PageType // Semantic role of the page.
+	// Title is the optional label used by EPUB navigation documents.
+	Title  string
+	Width  int
+	Height int
+	Spread string   // "left", "right", "center", "none".
+	Type   PageType // Semantic role of the page.
 }
 
 // Asset points to a binary object referenced from EPUB manifest.


### PR DESCRIPTION
## Summary

This PR adds an optional `Page.Title` field for supplying human-readable navigation labels.

When a title is provided, it is used consistently in:

- EPUB 3 navigation document (`nav.xhtml`)
- Optional EPUB 2 navigation document (`toc.ncx`)

For backward compatibility, pages without a title continue to use the existing `Page N` label.

## Why

The library currently generates generic table-of-contents entries such as `Page 1` and `Page 2`. This makes chapter-based EPUBs harder to navigate. Producers can now pass chapter names through `Page.Title` and get meaningful navigation entries without post-processing the generated EPUB.

## Changes

- Added an optional `Page.Title` field for human-readable EPUB navigation labels.
- Used `Page.Title` in both EPUB 3 `nav.xhtml` and optional EPUB 2 `toc.ncx`.
- Preserved the existing `Page N` fallback when a title is empty or whitespace-only.
- Added coverage for custom titles, XML escaping, and fallback behavior.

## How to Test

1. Run:

   ```bash
   go test ./...
   ```

2. Confirm all tests pass.

3. The added encoder test verifies that:
   - a title such as `Chapter & One` is XML-escaped and appears in both navigation files;
   - an empty title falls back to `Page 2`.

## Checklist

- [x] I used a Conventional Commits style PR title.
- [x] I tested my changes locally.
- [x] I updated docs if needed.